### PR TITLE
add lib with re-exports to cervo bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,17 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
-name = "cervo-asset"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "cervo-core",
- "cervo-nnef",
- "cervo-onnx",
-]
-
-[[package]]
-name = "cervo-cli"
+name = "cervo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -144,6 +134,16 @@ dependencies = [
  "log",
  "tempfile",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cervo-asset"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cervo-core",
+ "cervo-nnef",
+ "cervo-onnx",
 ]
 
 [[package]]

--- a/crates/cervo/Cargo.toml
+++ b/crates/cervo/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "cervo-cli"
+name = "cervo"
 version = "0.1.0"
 edition = "2021"
 authors = ["Tom Solberg <tom.solberg@emark-studios.com"]
 license = "LicenseRef-Embark-Proprietary"
 # this ensures cargo run in the workspace root uses cervo-cli
-default-run = "cervo-cli"
+default-run = "cervo"
 
 [dependencies]
 anyhow = "1.0.57"
@@ -17,3 +17,11 @@ cervo-onnx = { path = "../cervo-onnx" }
 cervo-nnef = { path = "../cervo-nnef" }
 cervo-asset = { path = "../cervo-asset" }
 cervo-core = { path = "../cervo-core" }
+
+[lib]
+name = "cervo"
+path = "src/lib.rs"
+
+[[bin]]
+name = "cervo"
+path = "src/main.rs"

--- a/crates/cervo/src/lib.rs
+++ b/crates/cervo/src/lib.rs
@@ -1,0 +1,7 @@
+/// Re-exports all subcrates without the prefixes.
+pub mod prelude {
+    pub use cervo_asset as asset;
+    pub use cervo_core as core;
+    pub use cervo_nnef as nnef;
+    pub use cervo_onnx as onnx;
+}


### PR DESCRIPTION
* adds a lib component to cervo
* re-exports all sub-crates as cervo::prelude::{ ... } to simplify end usage without depending on all subcrates