### PR TITLE
upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "cervo-core",
  "cervo-nnef",
  "cervo-onnx",
- "clap 3.1.18",
+ "clap",
  "log",
  "tempfile",
  "tracing-subscriber",
@@ -188,21 +188,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
@@ -213,9 +198,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "lazy_static",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -456,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "kstring"
@@ -477,9 +462,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libm"
@@ -711,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "paste"
@@ -746,9 +731,8 @@ dependencies = [
  "cervo-core",
  "cervo-nnef",
  "cervo-onnx",
- "clap 2.34.0",
+ "clap",
  "perchance",
- "structopt",
 ]
 
 [[package]]
@@ -842,11 +826,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1098,49 +1082,19 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1175,15 +1129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1271,8 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7925e7077194b730cdc9a9a91c454bfc03991f14e34f0fecd0e327558c94e034"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -1293,8 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be91babcd5c020498c2ad534d2810fdf285de13c1007d3853a5a86d87813e5b0"
 dependencies = [
  "anyhow",
  "educe",
@@ -1311,8 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2634afa31f55959a488f3cecf900fb9e9fa9ad6293091df99b14717bec8965a"
 dependencies = [
  "derive-new",
  "educe",
@@ -1322,8 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfc7107f3d3f0d493bb5cf9b0d4756a80b22c50a129586f9c6e559bcfc57ddf"
 dependencies = [
  "cc",
  "derive-new",
@@ -1345,8 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1537175515d258ba9243e30bc6ef64edcba7c3c162a932b3bb13c71d8054510"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1359,8 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c551b812161d3c916a2b6618e29637ef5823dafc69761aedf502bfe0ea3dd7ef"
 dependencies = [
  "bytes",
  "derive-new",
@@ -1378,8 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.16.7-pre"
-source = "git+https://github.com/sonos/tract?branch=issue-713#3434a9b88f7c7b1983d457582dafe697048f8459"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad3e60e7b331963de0d2156e7f88138f4e046b9d89745d752c56e33e6a789d6"
 dependencies = [
  "educe",
  "tract-nnef",
@@ -1398,6 +1350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,28 +1371,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,3 @@ members = [
     "crates/cervo-asset",
     "benchmarks/perf-test"
 ]
-
-[patch.crates-io]
-tract-onnx = { version = "0.16.7-pre", git = "https://github.com/sonos/tract", branch = "issue-713"}
-tract-nnef = { version = "0.16.7-pre", git = "https://github.com/sonos/tract", branch = "issue-713"}
-tract-hir = { version = "0.16.7-pre", git = "https://github.com/sonos/tract", branch = "issue-713"}
-tract-core = { version = "0.16.7-pre", git = "https://github.com/sonos/tract", branch = "issue-713"}

--- a/benchmarks/perf-test/Cargo.toml
+++ b/benchmarks/perf-test/Cargo.toml
@@ -3,14 +3,15 @@ name = "perf-test"
 version = "0.0.0"
 edition = "2018"
 license = "LicenseRef-Embark-Proprietary"
+publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
-clap = "2.33.0"
+clap = { version = "3.1.18", features = ["derive"] }
+
 anyhow = { version = "1.0"}
 cervo-onnx = { path = "../../crates/cervo-onnx" }
 cervo-nnef = { path = "../../crates/cervo-nnef" }
 cervo-core = { path = "../../crates/cervo-core" }
-structopt = "0.3.11"
-perchance = "*"
+perchance = "0.3"

--- a/benchmarks/perf-test/src/compare_batchers.rs
+++ b/benchmarks/perf-test/src/compare_batchers.rs
@@ -14,22 +14,22 @@ use std::{
 
 use anyhow::Result;
 use cervo_core::{EpsilonInjector, Inferer};
-use structopt::StructOpt;
+use clap::Parser;
 
 fn black_box<T>(dummy: T) -> T {
     unsafe { std::ptr::read_volatile(&dummy) }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub(crate) struct BatcherComparison {
-    #[structopt(long = "onnx", short = "o")]
+    #[clap(long = "onnx", short = 'o')]
     onnx: Option<PathBuf>,
-    #[structopt(long = "nnef", short = "n")]
+    #[clap(long = "nnef", short = 'n')]
     nnef: Option<PathBuf>,
 
-    #[structopt(short = "-f", long = "--fixed", use_delimiter = true)]
+    #[clap(short = 'f', long = "--fixed", use_value_delimiter = true)]
     fixed_sizes: Vec<usize>,
-    #[structopt(short = "-d", long = "--dynamic", use_delimiter = true)]
+    #[clap(short = 'd', long = "--dynamic", use_value_delimiter = true)]
     dynamic_sizes: Vec<usize>,
     steps: usize,
     batch_size: usize,

--- a/benchmarks/perf-test/src/compare_loading.rs
+++ b/benchmarks/perf-test/src/compare_loading.rs
@@ -14,13 +14,13 @@ use std::{
 };
 
 use cervo_onnx::simple_inferer_from_stream;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct LoadComparison {
-    #[structopt(long = "onnx", short = "o")]
+    #[clap(long = "onnx", short = 'o')]
     onnx: Option<PathBuf>,
-    #[structopt(long = "nnef", short = "n")]
+    #[clap(long = "nnef", short = 'n')]
     nnef: Option<PathBuf>,
 
     iterations: usize,

--- a/benchmarks/perf-test/src/compare_noise.rs
+++ b/benchmarks/perf-test/src/compare_noise.rs
@@ -15,13 +15,13 @@ use std::{
 use anyhow::Result;
 use cervo_core::{EpsilonInjector, Inferer, LowQualityNoiseGenerator};
 use cervo_onnx::fixed_batch_inferer_from_stream;
-use structopt::StructOpt;
+use clap::Parser;
 
 fn black_box<T>(dummy: T) -> T {
     unsafe { std::ptr::read_volatile(&dummy) }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub(crate) struct NoiseComparison {
     input_file: PathBuf,
     steps: usize,

--- a/benchmarks/perf-test/src/main.rs
+++ b/benchmarks/perf-test/src/main.rs
@@ -5,6 +5,7 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
 
+use clap::Parser;
 mod compare_batchers;
 mod compare_loading;
 mod compare_noise;
@@ -14,9 +15,7 @@ use compare_batchers::BatcherComparison;
 use compare_loading::LoadComparison;
 use compare_noise::NoiseComparison;
 
-use structopt::StructOpt;
-
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum MeasureMode {
     // BatchScaling,
     Batchers(BatcherComparison),
@@ -24,10 +23,10 @@ enum MeasureMode {
     Loading(LoadComparison),
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "foo")]
+#[derive(Debug, Parser)]
+#[clap(name = "cervo perf-tests")]
 struct RustyPerf {
-    #[structopt(subcommand)] // Note that we mark a field as a subcommand
+    #[clap(subcommand)] // Note that we mark a field as a subcommand
     mode: MeasureMode,
 }
 
@@ -56,7 +55,7 @@ struct RustyPerf {
 // }
 
 fn main() {
-    let args = RustyPerf::from_args();
+    let args = RustyPerf::parse();
 
     match args.mode {
         // MeasureMode::BatchScaling => {

--- a/crates/cervo-core/Cargo.toml
+++ b/crates/cervo-core/Cargo.toml
@@ -10,8 +10,8 @@ license = "LicenseRef-Embark-Proprietary"
 
 [dependencies]
 anyhow = { version = "1.0"}
-tract-core =  { version = "0.16.7-pre" }
-tract-hir =  { version = "0.16.7-pre" }
+tract-core =  { version = "0.16.7" }
+tract-hir =  { version = "0.16.7" }
 rand = { version = "0.8.2" }
 rand_distr = { version = "0.4" }
 perchance = { version = "^0.3"}

--- a/crates/cervo-nnef/Cargo.toml
+++ b/crates/cervo-nnef/Cargo.toml
@@ -9,8 +9,8 @@ license = "LicenseRef-Embark-Proprietary"
 
 [dependencies]
 anyhow = "1.0.57"
-tract-onnx =  { version = "0.16.7-pre" }
-tract-nnef = { version = "0.16.7-pre" }
-tract-hir = { version = "0.16.7-pre" }
+tract-onnx =  { version = "0.16.7" }
+tract-nnef = { version = "0.16.7" }
+tract-hir = { version = "0.16.7" }
 cervo-core = { path = "../cervo-core" }
 once_cell = "1.10"

--- a/crates/cervo-onnx/Cargo.toml
+++ b/crates/cervo-onnx/Cargo.toml
@@ -9,6 +9,6 @@ license = "LicenseRef-Embark-Proprietary"
 
 [dependencies]
 anyhow = "1.0.57"
-tract-onnx =  { version = "0.16.7-pre" }
-tract-nnef = { version = "0.16.7-pre" }
+tract-onnx =  { version = "0.16.7" }
+tract-nnef = { version = "0.16.7" }
 cervo-core = { path = "../cervo-core" }

--- a/deny.toml
+++ b/deny.toml
@@ -196,7 +196,7 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = ["https://github.com/sonos/tract.git"]
+allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for


### PR DESCRIPTION
Upgrades to use the newly released 0.16.7 of tract, and upgrades our old structopt use to clap.