### PR TITLE
Make to-nnef copy+remove from tmpfile instead of rename

### DIFF
--- a/crates/cervo/src/commands/to_nnef.rs
+++ b/crates/cervo/src/commands/to_nnef.rs
@@ -64,7 +64,6 @@ pub(super) fn onnx_to_nnef(config: ToNnefArgs) -> Result<()> {
     out.write_all(&bytes)?;
 
     std::fs::copy(&out, out_file)?;
-    std::fs::remove_file(&out)?;
 
     Ok(())
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Since `/tmp` is commonly mounted as a [`tmpfs`](https://www.kernel.org/doc/html/latest/filesystems/tmpfs.html) on various Linux distributions, using `std::fs::rename` from a tempfile located in `/tmp` might cause
```
Invalid cross-device link (os error 18)
```

The fix proposed here will instead do a `std::fs::copy`, with the tempfile getting removed when the handle is dropped.
