### PR TITLE
Add batcher API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 *.csv
 benchmarks/out
+/benchmarks/perf-test/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ Thus, to upgrade you'll need to:
 There's also a new `Batcher` which will help with batch building,
 while also improving performance. Using this helper will further
 reduce the number of allocations per call. On average, this is about a
-10% performance gain.
+10% performance gain. The easiest way to use this is using the
+`.into_batched()` on your existing inferer.
 
 Other changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+This update has a decently large rewrite.
 ## [0.2.0] - 2022-07-11
 
 * Upgrade all dependencies to tract 0.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
-This update has a decently large rewrite.
+This update focuses on improving performance and simplifying
+batching. To do this; there's a few changes that'll require updating
+your code. These should generally be fairly simple, and in some-cases
+as simple as removing `.to_owned()` and renaming a function call.
+
+* There's no owned strings in inputs and outputs. This saves
+  (`model-input-arity + model-output-arity) * avg-batch-size`
+  string allocations on each call.
+  * The values are still owned, as they act as sink/sourced. However;
+	internally there's been multiple allocations removed per batch
+	element.
+* The `InfererExt::infer` trait has been deprecated in favor of
+  `InfererExt::infer_single` and `InfererExt::infer_batch` which
+  allows some small optimizations while clarifying the API.
+
+Thus, to upgrade you'll need to:
+
+* Change how you build your batches to cache the input names.
+* Update which infer call function you use.
+
+There's also a new `Batcher` which will help with batch building,
+while also improving performance. Using this helper will further
+reduce the number of allocations per call. On average, this is about a
+10% performance gain.
+
+Other changes:
+
+* To match the new `Inferer` API; `NoiseGenerators` have to generate
+  noise in-place instead of into a new vector.
+
 ## [0.2.0] - 2022-07-11
 
 * Upgrade all dependencies to tract 0.17.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cervo-runtime"
+version = "0.2.1-alpha.0"
+dependencies = [
+ "cervo-core",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,13 +181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cervo-runtime"
-version = "0.2.1-alpha.0"
-dependencies = [
- "cervo-core",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
 members = [
     "crates/cervo",
+    "crates/cervo-asset",
     "crates/cervo-core",
     "crates/cervo-nnef",
     "crates/cervo-onnx",
-    "crates/cervo-asset",
+    "crates/cervo-runtime",
 ]
 
 exclude = [ "benchmarks/perf-test" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
     "crates/cervo-core",
     "crates/cervo-nnef",
     "crates/cervo-onnx",
-    "crates/cervo-runtime",
 ]
 
 exclude = [ "benchmarks/perf-test" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "crates/cervo-nnef",
     "crates/cervo-onnx",
     "crates/cervo-asset",
-#    "benchmarks/perf-test"
 ]
+
+exclude = [ "benchmarks/perf-test" ]

--- a/benchmarks/generate.sh
+++ b/benchmarks/generate.sh
@@ -31,4 +31,4 @@ mkdir -p ../out
 cargo run $FLAGS batch-scaling $count "../out/batchsize-$suffix.csv" -o ../../brains/test-large.onnx -b `seq -s, 1 24`
 python3 ../python/batchsize.py "../out/batchsize-$suffix.csv" $count "../out/batchsize-$suffix.png"
 
-python3 ../python/compare_batchsize.py "../out/batchsize-before.csv" "../out/batchsize-after.csv" $count "../out/batchsize-compare.png"
+python3 ../python/compare_batchsize.py "../out/batchsize-before.csv" "../out/batchsize-after.csv" 1000 "../out/batchsize-compare.png"

--- a/benchmarks/generate.sh
+++ b/benchmarks/generate.sh
@@ -31,4 +31,4 @@ mkdir -p ../out
 cargo run $FLAGS batch-scaling $count "../out/batchsize-$suffix.csv" -o ../../brains/test-large.onnx -b `seq -s, 1 24`
 python3 ../python/batchsize.py "../out/batchsize-$suffix.csv" $count "../out/batchsize-$suffix.png"
 
-python3 ../python/compare_batchsize.py "../out/batchsize-before.csv" "../out/batchsize-after.csv" 1000 "../out/batchsize-compare.png"
+python3 ../python/compare_batchsize.py "../out/batchsize-before.csv" "../out/batchsize-$suffix.csv" $count "../out/batchsize-compare.png"

--- a/benchmarks/generate.sh
+++ b/benchmarks/generate.sh
@@ -1,3 +1,5 @@
+set -eux
+
 if [ "$#" -lt 1 ] ; then
 	echo "usage: ./generate.sh SUFFIX"
 	exit 1
@@ -5,25 +7,28 @@ fi
 
 suffix="$1"
 
-count=1000
+count=10000
 if [ "$#" -ge 2 ] ; then
 	count=$2
 fi
 
 
-
-if ! python3 python/check_deps.py ; then
+if ! python3 ../python/check_deps.py ; then
 	exit 1
 fi
 
-cargo build --release --bin perf-test || exit 1
+FLAGS=--release
 
-mkdir -p out
-#  cargo run --release --bin perf-test batchers $count 20 "out/batchers-$suffix.csv" -o ../brains/test-large.onnx -n ../brains/test-large.nnef.tar -f 1,6
-# python3 python/batchers.py "out/batchers-$suffix.csv" 20 "out/batchers-$suffix.png"
+cargo build $FLAGS || exit 1
 
-# cargo run --release --bin perf-test loading 100 "out/loaders-$suffix.csv" -o ../brains/test-large.onnx -n ../brains/test-large.nnef.tar
-# python3 python/loaders.py "out/loaders-$suffix.csv" 100 "out/loaders-$suffix.png"
+mkdir -p ../out
+# cargo run $FLAGS batchers $count 20 "../out/batchers-$suffix.csv" -o ../../brains/test-large.onnx -n ../../brains/test-large.nnef.tar -f 1,6
+# python3 ../python/batchers.py "../out/batchers-$suffix.csv" 20 "../out/batchers-$suffix.png"
 
-cargo run --release --bin perf-test batch-scaling 100 "out/batchsize-$suffix.csv" -o ../brains/test-large.onnx -b `seq -s, 1 24`
-python3 python/batchsize.py "out/batchsize-$suffix.csv" 100 "out/batchsize-$suffix.png"
+# cargo run $FLAGS loading $count "../out/loaders-$suffix.csv" -o ../../brains/test-large.onnx -n ../../brains/test-large.nnef.tar
+# python3 ../python/loaders.py "../out/loaders-$suffix.csv" $count "../out/loaders-$suffix.png"
+
+cargo run $FLAGS batch-scaling $count "../out/batchsize-$suffix.csv" -o ../../brains/test-large.onnx -b `seq -s, 1 24`
+python3 ../python/batchsize.py "../out/batchsize-$suffix.csv" $count "../out/batchsize-$suffix.png"
+
+python3 ../python/compare_batchsize.py "../out/batchsize-before.csv" "../out/batchsize-after.csv" $count "../out/batchsize-compare.png"

--- a/benchmarks/perf-test/src/compare_batchers.rs
+++ b/benchmarks/perf-test/src/compare_batchers.rs
@@ -62,7 +62,7 @@ fn execute_steps(
         };
 
         let start = Instant::now();
-        let res = inferer.infer(obs)?;
+        let res = inferer.infer_batch(obs)?;
         black_box(&res);
         let elapsed = start.elapsed();
 

--- a/benchmarks/perf-test/src/compare_batchers.rs
+++ b/benchmarks/perf-test/src/compare_batchers.rs
@@ -49,8 +49,8 @@ fn execute_steps(
     batch_size: usize,
 ) -> Result<Vec<Measurement>> {
     perchance::seed_global(0xff00ff00ff00ff00ff00ff00ff00ff00u128);
-    let observations =
-        crate::helpers::build_inputs_from_desc(batch_size as u64, inferer.input_shapes());
+    let inputs = inferer.input_shapes().to_vec();
+    let observations = crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs);
 
     let mut measurements = vec![];
     for step in 0..steps {
@@ -58,7 +58,7 @@ fn execute_steps(
             observations.clone()
         } else {
             let batch_size = perchance::global().uniform_range_usize(1..10);
-            crate::helpers::build_inputs_from_desc(batch_size as u64, inferer.input_shapes())
+            crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs)
         };
 
         let start = Instant::now();

--- a/benchmarks/perf-test/src/compare_batchsize.rs
+++ b/benchmarks/perf-test/src/compare_batchsize.rs
@@ -7,7 +7,7 @@
 */
 
 use anyhow::Result;
-use cervo_core::prelude::{Inferer, State};
+use cervo_core::prelude::{Batcher, Inferer, InfererExt, State};
 use std::{
     collections::HashMap,
     io::{Cursor, Write},
@@ -84,10 +84,12 @@ fn execute_load_metrics<I: Inferer>(
         black_box(&(inferer.infer(batch)?));
     }
 
+    let mut batcher = Batcher::new_for_inferer(inferer);
     for _ in 0..(count / batch_size) {
         let start = Instant::now();
         let batch = data.clone();
-        black_box(&(inferer.infer(batch)?));
+        batcher.extend(batch);
+        black_box(&(batcher.execute(inferer)?));
         times.push(start.elapsed().as_secs_f64() * 1000.0 / batch_size as f64);
     }
 
@@ -115,11 +117,11 @@ fn run_batch_size(o: &Path, batch_sizes: Vec<usize>, iterations: usize) -> Resul
             .map(|batch_size| {
                 println!("Checking batch size: {:?}", batch_size);
 
-                let mut inferer = builder(&mut Cursor::new(&data)).build_fixed(&[batch_size])?;
-                let batch = crate::helpers::build_inputs_from_desc(
-                    batch_size as u64,
-                    inferer.input_shapes(),
-                );
+                let mut inferer = builder(&mut Cursor::new(&data))
+                    .build_fixed(&[batch_size])?
+                    .with_default_epsilon("epsilon")?;
+                let inputs = inferer.input_shapes().to_vec();
+                let batch = crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs);
 
                 execute_load_metrics("fixed", batch_size, batch, iterations, &mut inferer)
             })
@@ -133,11 +135,11 @@ fn run_batch_size(o: &Path, batch_sizes: Vec<usize>, iterations: usize) -> Resul
             .map(|batch_size| {
                 println!("Checking batch size: {:?}", batch_size);
 
-                let mut inferer = builder(&mut Cursor::new(&data)).build_basic()?;
-                let batch = crate::helpers::build_inputs_from_desc(
-                    batch_size as u64,
-                    inferer.input_shapes(),
-                );
+                let mut inferer = builder(&mut Cursor::new(&data))
+                    .build_basic()?
+                    .with_default_epsilon("epsilon")?;
+                let inputs = inferer.input_shapes().to_vec();
+                let batch = crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs);
 
                 execute_load_metrics("single", batch_size, batch, iterations, &mut inferer)
             })
@@ -151,12 +153,11 @@ fn run_batch_size(o: &Path, batch_sizes: Vec<usize>, iterations: usize) -> Resul
             .map(|batch_size| {
                 println!("Checking batch size: {:?}", batch_size);
 
-                let mut inferer =
-                    builder(&mut Cursor::new(&data)).build_memoizing(&[batch_size])?;
-                let batch = crate::helpers::build_inputs_from_desc(
-                    batch_size as u64,
-                    inferer.input_shapes(),
-                );
+                let mut inferer = builder(&mut Cursor::new(&data))
+                    .build_memoizing(&[batch_size])?
+                    .with_default_epsilon("epsilon")?;
+                let inputs = inferer.input_shapes().to_vec();
+                let batch = crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs);
 
                 execute_load_metrics("dynamic", batch_size, batch, iterations, &mut inferer)
             })
@@ -169,11 +170,12 @@ fn run_batch_size(o: &Path, batch_sizes: Vec<usize>, iterations: usize) -> Resul
             .map(|batch_size| {
                 println!("Checking batch size: {:?}", batch_size);
 
-                let mut inferer = builder(&mut Cursor::new(&data)).build_dynamic()?;
-                let batch = crate::helpers::build_inputs_from_desc(
-                    batch_size as u64,
-                    inferer.input_shapes(),
-                );
+                let mut inferer = builder(&mut Cursor::new(&data))
+                    .build_dynamic()?
+                    .with_default_epsilon("epsilon")?;
+
+                let inputs = inferer.input_shapes().to_vec();
+                let batch = crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs);
 
                 execute_load_metrics("direct", batch_size, batch, iterations, &mut inferer)
             })

--- a/benchmarks/perf-test/src/compare_batchsize.rs
+++ b/benchmarks/perf-test/src/compare_batchsize.rs
@@ -85,8 +85,8 @@ fn execute_load_metrics<I: Inferer>(
     }
 
     for _ in 0..(count / batch_size) {
-        let batch = data.clone();
         let start = Instant::now();
+        let batch = data.clone();
         black_box(&(inferer.infer(batch)?));
         times.push(start.elapsed().as_secs_f64() * 1000.0 / batch_size as f64);
     }

--- a/benchmarks/perf-test/src/compare_noise.rs
+++ b/benchmarks/perf-test/src/compare_noise.rs
@@ -47,7 +47,7 @@ fn execute_steps(
     for step in 0..steps {
         let obs = observations.clone();
         let start = Instant::now();
-        let res = inferer.infer(obs)?;
+        let res = inferer.infer_batch(obs)?;
         black_box(&res);
         let elapsed = start.elapsed();
 

--- a/benchmarks/perf-test/src/compare_noise.rs
+++ b/benchmarks/perf-test/src/compare_noise.rs
@@ -40,8 +40,8 @@ fn execute_steps(
     steps: usize,
     batch_size: usize,
 ) -> Result<Vec<Measurement>> {
-    let observations =
-        crate::helpers::build_inputs_from_desc(batch_size as u64, inferer.input_shapes());
+    let inputs = inferer.input_shapes().to_vec();
+    let observations = crate::helpers::build_inputs_from_desc(batch_size as u64, &inputs);
 
     let mut measurements = vec![];
     for step in 0..steps {

--- a/benchmarks/perf-test/src/helpers.rs
+++ b/benchmarks/perf-test/src/helpers.rs
@@ -14,7 +14,10 @@ pub fn get_file<T: AsRef<Path>>(name: T) -> std::io::Result<File> {
     std::fs::File::open(name)
 }
 
-pub fn build_inputs_from_desc(count: u64, inputs: &[(String, Vec<usize>)]) -> HashMap<u64, State> {
+pub fn build_inputs_from_desc<'a>(
+    count: u64,
+    inputs: &'a [(String, Vec<usize>)],
+) -> HashMap<u64, State<'a>> {
     (0..count)
         .map(|idx| {
             (
@@ -22,7 +25,8 @@ pub fn build_inputs_from_desc(count: u64, inputs: &[(String, Vec<usize>)]) -> Ha
                 State {
                     data: inputs
                         .iter()
-                        .map(|(key, count)| ((*key).clone(), vec![0.0; count.iter().product()]))
+                        .filter(|(key, count)| key != "epsilon")
+                        .map(|(key, count)| (key.as_str(), vec![0.0; count.iter().product()]))
                         .collect(),
                 },
             )

--- a/benchmarks/perf-test/src/helpers.rs
+++ b/benchmarks/perf-test/src/helpers.rs
@@ -14,10 +14,10 @@ pub fn get_file<T: AsRef<Path>>(name: T) -> std::io::Result<File> {
     std::fs::File::open(name)
 }
 
-pub fn build_inputs_from_desc<'a>(
+pub fn build_inputs_from_desc(
     count: u64,
-    inputs: &'a [(String, Vec<usize>)],
-) -> HashMap<u64, State<'a>> {
+    inputs: &[(String, Vec<usize>)],
+) -> HashMap<u64, State<'_>> {
     (0..count)
         .map(|idx| {
             (
@@ -25,7 +25,7 @@ pub fn build_inputs_from_desc<'a>(
                 State {
                     data: inputs
                         .iter()
-                        .filter(|(key, count)| key != "epsilon")
+                        .filter(|(key, _)| key != "epsilon")
                         .map(|(key, count)| (key.as_str(), vec![0.0; count.iter().product()]))
                         .collect(),
                 },

--- a/benchmarks/perf-test/src/main.rs
+++ b/benchmarks/perf-test/src/main.rs
@@ -43,7 +43,7 @@ struct RustyPerf {
 //         let start = Instant::now();
 
 //         for _ in 0..10 {
-//             instance.infer(observations.clone()).unwrap();
+//             instance.infer_batch(observations.clone()).unwrap();
 //         }
 //         let elapsed = start.elapsed();
 

--- a/benchmarks/perf-test/src/main.rs
+++ b/benchmarks/perf-test/src/main.rs
@@ -28,7 +28,7 @@ enum MeasureMode {
 #[derive(Debug, Parser)]
 #[clap(name = "cervo perf-tests")]
 struct RustyPerf {
-    #[clap(subcommand)] // Note that we mark a field as a subcommand
+    #[clap(subcommand)]
     mode: MeasureMode,
 }
 

--- a/benchmarks/python/compare_batchsize.py
+++ b/benchmarks/python/compare_batchsize.py
@@ -4,6 +4,8 @@ import matplotlib.pyplot as plt
 import pandas
 import seaborn
 
+KIND = "fixed"
+
 
 def parse_stats_file(statsfile) -> pandas.DataFrame:
     return pandas.read_csv(statsfile, names=["kind", "batchsize", "ms", "stddev"])
@@ -11,30 +13,74 @@ def parse_stats_file(statsfile) -> pandas.DataFrame:
 
 def main(statsfile1, statsfile2, iterations, outfile=None):
     df1 = parse_stats_file(statsfile1)
-    first = df1.where(df1["kind"] == "fixed")
-    first["kind"] = "before"
-
     df2 = parse_stats_file(statsfile2)
-    second = df2.where(df2["kind"] == "fixed")
-    second["kind"] = "after"
 
-    df = pandas.concat([first, second], ignore_index=True)
-    fig, ax = plt.subplots(nrows=2, figsize=(16, 16))
+    df = pandas.DataFrame.merge(
+        df1, df2, on=["kind", "batchsize"], how="outer", suffixes=["_before", "_after"]
+    )
+    df["ratio"] = df["ms_after"] / df["ms_before"]
 
-    seaborn.lineplot(x="batchsize", y="ms", hue="kind", data=df, ax=ax[0]).set(
+    df_melted = pandas.melt(
+        df, id_vars=["kind", "batchsize"], value_vars=["ms_before", "ms_after"]
+    )
+
+    fig, ax = plt.subplots(nrows=3, figsize=(16, 16))
+
+    seaborn.lineplot(
+        x="batchsize",
+        y="value",
+        hue="variable",
+        data=df_melted.where(df_melted["kind"] == KIND),
+        ax=ax[0],
+    ).set(
         title=f"Mean execution time by batch size (concretized), its={iterations}",
         ylabel="milliseconds",
         ylim=(0, 1),
     )
 
-    df["ms"] = df["ms"] * df["batchsize"]
+    df["ms_before"] = df["ms_before"] * df["batchsize"]
+    df["ms_after"] = df["ms_after"] * df["batchsize"]
 
-    # seaborn.factorplot(x="batchsize", y="ms", col="kind", data=df, kind="bar").set(
-    seaborn.lineplot(x="batchsize", y="ms", hue="kind", data=df, ax=ax[1]).set(
+    df_melted = pandas.melt(
+        df, id_vars=["kind", "batchsize"], value_vars=["ms_before", "ms_after"]
+    )
+
+    seaborn.lineplot(
+        x="batchsize",
+        y="value",
+        hue="variable",
+        data=df_melted.where(df_melted["kind"] == KIND),
+        ax=ax[1],
+    ).set(
         title=f"Total execution time by batch size (concretized), its={iterations}",
         ylabel="milliseconds",
         ylim=(0, 10),
     )
+
+    df_melted = pandas.melt(df, id_vars=["kind", "batchsize"], value_vars=["ratio"])
+    seaborn.barplot(
+        x="batchsize",
+        y="value",
+        hue="variable",
+        data=df_melted.where(df_melted["kind"] == KIND),
+        ax=ax[2],
+    ).set(
+        title=f"Relative improvement",
+        ylabel="Relative speed",
+        ylim=(0.6, 1.4),
+    )
+
+    # print(df.where(df["partition"] == "before")["ms"])
+    # r = (
+    #     df.where(df["partition"] == "before")["ms"]
+    #     / df.where(df["partition"] == "after")["ms"]
+    # )
+    # print(r)
+    # seaborn.lineplot(x=list(range(1, 25)), y=r, data=df, ax=ax[2],).set(
+    #     title=f"Total execution time by batch size (concretized), its={iterations}",
+    #     ylabel="milliseconds",
+    #     ylim=(0, 10),
+    # )
 
     if outfile:
         plt.savefig(outfile)

--- a/benchmarks/python/compare_batchsize.py
+++ b/benchmarks/python/compare_batchsize.py
@@ -1,0 +1,58 @@
+import sys
+
+import matplotlib.pyplot as plt
+import pandas
+import seaborn
+
+
+def parse_stats_file(statsfile) -> pandas.DataFrame:
+    return pandas.read_csv(statsfile, names=["kind", "batchsize", "ms", "stddev"])
+
+
+def main(statsfile1, statsfile2, iterations, outfile=None):
+    df1 = parse_stats_file(statsfile1)
+    first = df1.where(df1["kind"] == "fixed")
+    first["kind"] = "before"
+
+    df2 = parse_stats_file(statsfile2)
+    second = df2.where(df2["kind"] == "fixed")
+    second["kind"] = "after"
+
+    df = pandas.concat([first, second], ignore_index=True)
+    fig, ax = plt.subplots(nrows=2, figsize=(16, 16))
+
+    seaborn.lineplot(x="batchsize", y="ms", hue="kind", data=df, ax=ax[0]).set(
+        title=f"Mean execution time by batch size (concretized), its={iterations}",
+        ylabel="milliseconds",
+        ylim=(0, 1),
+    )
+
+    df["ms"] = df["ms"] * df["batchsize"]
+
+    # seaborn.factorplot(x="batchsize", y="ms", col="kind", data=df, kind="bar").set(
+    seaborn.lineplot(x="batchsize", y="ms", hue="kind", data=df, ax=ax[1]).set(
+        title=f"Total execution time by batch size (concretized), its={iterations}",
+        ylabel="milliseconds",
+        ylim=(0, 10),
+    )
+
+    if outfile:
+        plt.savefig(outfile)
+
+    else:
+        plt.show()
+
+
+def get_or_none(lst, idx):
+    if idx >= len(lst):
+        return None
+
+    return lst[idx]
+
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+    filename2 = sys.argv[2]
+    bs = sys.argv[3]
+
+    main(filename, filename2, bs, get_or_none(sys.argv, 4))

--- a/crates/cervo-asset/tests/helpers.rs
+++ b/crates/cervo-asset/tests/helpers.rs
@@ -28,7 +28,7 @@ pub fn build_inputs_from_desc(count: u64, inputs: &[(String, Vec<usize>)]) -> Ha
                 State {
                     data: inputs
                         .iter()
-                        .map(|(key, count)| ((*key).clone(), vec![0.0; count.iter().product()]))
+                        .map(|(key, count)| (key.as_str(), vec![0.0; count.iter().product()]))
                         .collect(),
                 },
             )

--- a/crates/cervo-asset/tests/infer-simple.rs
+++ b/crates/cervo-asset/tests/infer-simple.rs
@@ -7,7 +7,7 @@
 */
 
 use cervo_asset::AssetData;
-use cervo_core::prelude::{EpsilonInjector, Inferer, InfererExt};
+use cervo_core::prelude::{Inferer, InfererExt};
 
 #[path = "./helpers.rs"]
 mod helpers;
@@ -22,9 +22,10 @@ fn test_infer_once_basic() {
         .with_default_epsilon("epsilon")
         .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(1, instance.input_shapes());
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(1, &shapes);
 
-    let result = instance.infer(observations);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();
@@ -35,17 +36,16 @@ fn test_infer_once_basic() {
 #[test]
 fn test_infer_once_basic_nnef() {
     let mut reader = helpers::get_file("test-nnef.crvo").unwrap();
-    let instance = AssetData::deserialize(&mut reader)
+    let mut instance = AssetData::deserialize(&mut reader)
         .expect("a valid asset")
         .load_basic()
         .expect("an inferer")
         .with_default_epsilon("epsilon")
         .expect("a noise wrapper");
 
-    let mut instance = EpsilonInjector::wrap(instance, "epsilon").unwrap();
-    let observations = helpers::build_inputs_from_desc(1, instance.input_shapes());
-
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(1, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();

--- a/crates/cervo-core/src/batcher.rs
+++ b/crates/cervo-core/src/batcher.rs
@@ -1,0 +1,161 @@
+// Author: Tom Solberg <tom.solberg@embark-studios.com>
+// Copyright © 2022, Tom Solberg, all rights reserved.
+// Created: 22 July 2022
+
+/*!
+
+*/
+
+use std::collections::HashMap;
+
+use crate::inferer::{Batch, BatchResponse, Inferer, Response, State};
+
+pub struct Batcher {
+    states: Vec<Option<Vec<f32>>>,
+    ids: Vec<u64>,
+    input_key_to_slot: Vec<String>,
+    output_key_to_slot: Vec<String>,
+
+    batch_sizes: usize,
+}
+
+impl Batcher {
+    pub fn new_for_inferer(inferer: &dyn Inferer) -> Self {
+        let input_key_to_slot: Vec<_> = inferer
+            .input_shapes()
+            .iter()
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        let output_key_to_slot: Vec<_> = inferer
+            .output_shapes()
+            .iter()
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        let states = vec![None; input_key_to_slot.len()];
+        Self {
+            states,
+            ids: vec![],
+            input_key_to_slot,
+            output_key_to_slot,
+            batch_sizes: 0,
+        }
+    }
+
+    #[inline]
+    fn slot(&self, name: &str) -> Option<usize> {
+        self.input_key_to_slot.iter().position(|k| k == name)
+    }
+
+    /// Insert a single element into the batch to include in the next execution.
+    pub fn push(&mut self, id: u64, state: State<'_>) -> anyhow::Result<()> {
+        for (k, v) in state.data {
+            let slot = self
+                .slot(k)
+                .ok_or_else(|| anyhow::anyhow!("key doesn't match an input: {:?}", k))?;
+
+            if self.states[slot].is_none() {
+                self.states[slot] = Some(vec![])
+            }
+
+            self.states[slot].as_mut().unwrap().extend_from_slice(&v);
+        }
+
+        self.ids.push(id);
+        self.batch_sizes += 1;
+        Ok(())
+    }
+
+    /// Insert a sequence of elements into the batch to include in the next execution.
+    pub fn extend<'a, Iter: IntoIterator<Item = (u64, State<'a>)>>(
+        &mut self,
+        states: Iter,
+    ) -> anyhow::Result<()> {
+        for (id, state) in states {
+            self.push(id, state)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn execute<'a, 'b>(
+        &'a mut self,
+        inferer: &'b mut impl Inferer,
+    ) -> anyhow::Result<HashMap<u64, Response<'b>>> {
+        let mut total_offset = 0;
+        let mut response = BatchResponse::empty();
+
+        for k in &self.output_key_to_slot {
+            response.data.push((k, vec![]));
+        }
+
+        let empty = [];
+        // pick up as many items as possible (by slicing the stores) and feed into the model.
+        // this builds up a set of output stores that'll feed in sequence.
+        while self.batch_sizes > 0 {
+            let preferred_batch_size = inferer.select_batch_size(self.batch_sizes);
+            self.batch_sizes -= preferred_batch_size;
+
+            let mut batch = Batch::empty();
+            batch.count = preferred_batch_size;
+
+            for ((slot, (k, shape)), name) in inferer
+                .input_shapes()
+                .iter()
+                .enumerate()
+                .zip(self.input_key_to_slot.iter())
+            {
+                assert_eq!(k, name);
+                let batch_elements: usize = shape.iter().product();
+
+                // This is to deal with epsilon or other generative inferer wrappers.
+                if let Some(store) = &self.states[slot] {
+                    let batch_data = &store[(total_offset * batch_elements)
+                        ..(total_offset + preferred_batch_size) * batch_elements];
+
+                    batch.insert(name, batch_data);
+                } else {
+                    batch.insert(name, &empty);
+                }
+            }
+
+            let batch_response = inferer.infer_batched(batch)?;
+            response.append(batch_response);
+            total_offset += preferred_batch_size;
+        }
+
+        self.states
+            .iter_mut()
+            .filter_map(|e| e.as_mut())
+            .for_each(|e| e.clear());
+
+        let mut output = HashMap::default();
+
+        let mut total_offset = 0;
+        for id in self.ids.drain(..) {
+            let mut output_response = Response::empty();
+            for ((idx, key), (name, shape)) in self
+                .output_key_to_slot
+                .iter()
+                .enumerate()
+                .zip(inferer.output_shapes())
+            {
+                assert_eq!(name, key);
+                let batch_elements: usize = shape.iter().product();
+                let slot_response = &response.data[idx];
+                assert_eq!(slot_response.0, key);
+                let batch_data = slot_response.1
+                    [(total_offset * batch_elements)..(total_offset + 1) * batch_elements]
+                    .to_owned();
+
+                output_response.data.insert(name, batch_data);
+            }
+
+            total_offset += 1;
+            output.insert(id, output_response);
+        }
+
+        Ok(output)
+    }
+}

--- a/crates/cervo-core/src/batcher.rs
+++ b/crates/cervo-core/src/batcher.rs
@@ -207,7 +207,9 @@ impl<'a> ScratchPadView<'a> {
     pub fn output_name(&self, slot: usize) -> &str {
         self.pad.output_name(slot)
     }
-    /// See [`ScratchPad::len`].
+
+    /// The batch size of this view.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.batch_range.len()
     }

--- a/crates/cervo-core/src/batcher.rs
+++ b/crates/cervo-core/src/batcher.rs
@@ -3,229 +3,33 @@
 // Created: 22 July 2022
 
 /*!
+Tools for batching and batched execution.
 
+Batching leads to lower memory pressure by reusing data gathering
+allocations, and higher performance by being able to run larger
+kernels. This is especially noticeable for networks with large matrix
+multiplications where the weights do not fit in the CPU cache.
 */
 
+mod scratch;
+mod wrapper;
+
+use self::scratch::ScratchPad;
 use crate::inferer::{Inferer, Response, State};
-use std::{collections::HashMap, ops::Range};
-use tract_core::tract_data::TVec;
+pub use scratch::ScratchPadView;
+use std::collections::HashMap;
+pub use wrapper::Batched;
 
-/// Data container for a single slot in the scratchpad.
-struct ScratchPadData {
-    /// The slot name in the model input
-    name: String,
-
-    /// The data store
-    data: Vec<f32>,
-
-    /// Number of data elements per batch-element.
-    count: usize,
-}
-
-impl ScratchPadData {
-    /// Construct a new slot data with the specified capacity and element count.
-    fn new(name: String, count: usize, capacity: usize) -> Self {
-        let mut this = Self {
-            name,
-            data: vec![],
-            count,
-        };
-
-        this.reserve(capacity);
-        this
-    }
-
-    /// Reserve space for this many batch elemeents.
-    fn reserve(&mut self, batch_size: usize) {
-        self.data.resize(batch_size * self.count, 0.0);
-    }
-
-    /// A view over the specified range of batch elements.
-    #[inline]
-    fn view(&self, range: Range<usize>) -> &[f32] {
-        &self.data[range.start * self.count..range.end * self.count]
-    }
-
-    /// A mutable view over the specified range of batch elements.
-    #[inline]
-    fn view_mut(&mut self, range: Range<usize>) -> &mut [f32] {
-        &mut self.data[range.start * self.count..range.end * self.count]
-    }
-}
-
-const DEFAULT_CAPACITY: usize = 6;
-/// A scratch pad used during each inference call to avoid fragmented
-/// allocations and copying.
-pub struct ScratchPad {
-    inputs: TVec<ScratchPadData>,
-    outputs: TVec<ScratchPadData>,
-    ids: Vec<u64>,
-    batch_size: usize,
-    capacity: usize,
-}
-
-impl ScratchPad {
-    // TODO[TSolberg]: When switching to raw ModelAPI, fix this.
-    /// Construct a new scratchpad for the provided API.
-    pub fn new_for_shapes(
-        inputs: &[(String, Vec<usize>)],
-        outputs: &[(String, Vec<usize>)],
-    ) -> Self {
-        Self::new_with_size(inputs, outputs, DEFAULT_CAPACITY)
-    }
-
-    // TODO[TSolberg]: When switching to raw ModelAPI, fix this.
-    /// Construct a new scratchpad for the provided API with a specified default capacity.
-    pub fn new_with_size(
-        inputs: &[(String, Vec<usize>)],
-        outputs: &[(String, Vec<usize>)],
-        capacity: usize,
-    ) -> Self {
-        let inputs = inputs
-            .iter()
-            .map(|(name, shape)| {
-                let count = shape.iter().product();
-                ScratchPadData::new(name.to_owned(), count, capacity)
-            })
-            .collect();
-
-        let outputs = outputs
-            .iter()
-            .map(|(name, shape)| {
-                let count = shape.iter().product();
-                ScratchPadData::new(name.to_owned(), count, capacity)
-            })
-            .collect();
-
-        Self {
-            inputs,
-            outputs,
-            ids: vec![],
-            batch_size: 0,
-            capacity,
-        }
-    }
-
-    /// Prepare the next slot to store data for the provided id.
-    pub fn next(&mut self, id: u64) {
-        self.batch_size += 1;
-        self.ids.push(id);
-
-        if self.batch_size > self.capacity {
-            self.capacity *= 2;
-
-            for slot in &mut self.inputs {
-                slot.reserve(self.capacity);
-            }
-        }
-    }
-
-    /// Push data for the specific slot.
-    pub fn push(&mut self, slot: usize, data: Vec<f32>) {
-        self.inputs[slot]
-            .view_mut(self.batch_size - 1..self.batch_size)
-            .copy_from_slice(&data);
-    }
-
-    /// View the chunk starting at batch-element `offset` containing `size` elements.x
-    pub fn chunk(&mut self, offset: usize, size: usize) -> ScratchPadView {
-        let size = size.min(self.batch_size);
-        self.batch_size -= size;
-
-        ScratchPadView {
-            pad: self,
-            batch_range: offset..offset + size,
-        }
-    }
-
-    /// View of the specified `range` of input at location `slot`.
-    #[inline]
-    pub(crate) fn input_slot(&self, slot: usize, range: Range<usize>) -> &[f32] {
-        self.inputs[slot].view(range)
-    }
-
-    /// A mutable view of the specified `range` of input at location `slot`.
-    #[inline]
-    pub(crate) fn input_slot_mut(&mut self, slot: usize, range: Range<usize>) -> &mut [f32] {
-        self.inputs[slot].view_mut(range)
-    }
-
-    /// Retrieve the input name for `slot`.
-    #[inline]
-    pub(crate) fn input_name(&self, slot: usize) -> &str {
-        &self.inputs[slot].name
-    }
-
-    /// View of the specified `range` of output at location `slot`.
-    #[inline]
-    pub(crate) fn output_slot(&self, slot: usize, range: Range<usize>) -> &[f32] {
-        self.outputs[slot].view(range)
-    }
-
-    /// A mutable view of the specified `range` of output at location `slot`.
-    #[inline]
-    pub(crate) fn output_slot_mut(&mut self, slot: usize, range: Range<usize>) -> &mut [f32] {
-        self.outputs[slot].view_mut(range)
-    }
-
-    /// Retrieve the output name for `slot`.
-    #[inline]
-    pub(crate) fn output_name(&self, slot: usize) -> &str {
-        &self.outputs[slot].name
-    }
-}
-
-/// A view over a set of batch elements in a scratch pad.
-pub struct ScratchPadView<'a> {
-    pad: &'a mut ScratchPad,
-    batch_range: Range<usize>,
-}
-
-impl<'a> ScratchPadView<'a> {
-    /// View of the input at location `slot`.
-    pub fn input_slot(&self, slot: usize) -> &[f32] {
-        self.pad.input_slot(slot, self.batch_range.clone())
-    }
-
-    /// A mutable view of the input at location `slot`.
-    pub fn input_slot_mut(&mut self, slot: usize) -> &mut [f32] {
-        self.pad.input_slot_mut(slot, self.batch_range.clone())
-    }
-
-    /// Retrieve the input name for `slot`.
-    pub fn input_name(&self, slot: usize) -> &str {
-        self.pad.input_name(slot)
-    }
-
-    /// A mutable view of the data at input `slot`.
-    pub fn output_slot(&self, slot: usize) -> &[f32] {
-        self.pad.output_slot(slot, self.batch_range.clone())
-    }
-
-    /// A mutable view of the data at location `slot`.
-    pub fn output_slot_mut(&mut self, slot: usize) -> &mut [f32] {
-        self.pad.output_slot_mut(slot, self.batch_range.clone())
-    }
-
-    /// Retrieve the output name for `slot`.
-    pub fn output_name(&self, slot: usize) -> &str {
-        self.pad.output_name(slot)
-    }
-
-    /// The batch size of this view.
-    #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
-        self.batch_range.len()
-    }
-}
-
-/// A batcher to help transition from per-entity code to batched inference.
+/// Low-level batch builder to help transition from per-entity code to
+/// batched inference. Consider using the [`Batched`] wrapper instead
+/// to avoid tracking two objects.
 ///
 /// Reusing this across frames will have a noticeable performance
 /// impact for large model inputs or outputs, and reduce memory
 /// pressure.
 ///
-/// Note that Batchers are connected to a specific inferer.
+/// Note that Batchers are specific to the inferer used for
+/// initialization.
 pub struct Batcher {
     scratch: ScratchPad,
 }
@@ -316,47 +120,5 @@ impl Batcher {
         Ok(HashMap::from_iter(
             self.scratch.ids.drain(..).zip(outputs.into_iter()),
         ))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    mod scratchppaddata {
-        use super::super::ScratchPadData;
-        #[test]
-        fn has_right_initial_space() {
-            let spd = ScratchPadData::new("epsilon".to_owned(), 24, 2);
-
-            assert_eq!(spd.count, 24);
-            assert_eq!(spd.data.len(), 48);
-            assert_eq!(spd.name, "epsilon");
-        }
-
-        #[test]
-        fn reserves_correct_size() {
-            let mut spd = ScratchPadData::new("epsilon".to_owned(), 24, 2);
-
-            spd.reserve(4);
-            assert_eq!(spd.count, 24);
-            assert_eq!(spd.data.len(), 24 * 4);
-        }
-
-        #[test]
-        fn views_correct_range() {
-            let mut spd = ScratchPadData::new("epsilon".to_owned(), 6, 4);
-
-            spd.reserve(4);
-            for idx in 0..24 {
-                spd.data[idx] = idx as f32;
-            }
-
-            assert_eq!(spd.view(0..1), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
-            assert_eq!(spd.view_mut(0..1), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
-            assert_eq!(spd.view(1..2), [6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
-            assert_eq!(spd.view_mut(1..2), [6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
-
-            assert_eq!(spd.view(3..4), [18.0, 19.0, 20.0, 21.0, 22.0, 23.0]);
-            assert_eq!(spd.view_mut(3..4), [18.0, 19.0, 20.0, 21.0, 22.0, 23.0]);
-        }
     }
 }

--- a/crates/cervo-core/src/batcher/scratch.rs
+++ b/crates/cervo-core/src/batcher/scratch.rs
@@ -1,5 +1,5 @@
 // Author: Tom Solberg <tom.solberg@embark-studios.com>
-// Copyright © 2022, Tom Solberg, all rights reserved.
+// Copyright © 2022, Embark Studios, all rights reserved.
 // Created: 27 July 2022
 
 /*!

--- a/crates/cervo-core/src/batcher/scratch.rs
+++ b/crates/cervo-core/src/batcher/scratch.rs
@@ -1,0 +1,261 @@
+// Author: Tom Solberg <tom.solberg@embark-studios.com>
+// Copyright © 2022, Tom Solberg, all rights reserved.
+// Created: 27 July 2022
+
+/*!
+
+*/
+
+use std::ops::Range;
+use tract_core::tract_data::TVec;
+
+/// Data container for a single slot in the scratchpad.
+pub(super) struct ScratchPadData {
+    /// The slot name in the model input
+    pub(super) name: String,
+
+    /// The data store
+    pub(super) data: Vec<f32>,
+
+    /// Number of data elements per batch-element.
+    pub(super) count: usize,
+}
+
+impl ScratchPadData {
+    /// Construct a new slot data with the specified capacity and element count.
+    fn new(name: String, count: usize, capacity: usize) -> Self {
+        let mut this = Self {
+            name,
+            data: vec![],
+            count,
+        };
+
+        this.reserve(capacity);
+        this
+    }
+
+    /// Reserve space for this many batch elemeents.
+    fn reserve(&mut self, batch_size: usize) {
+        self.data.resize(batch_size * self.count, 0.0);
+    }
+
+    /// A view over the specified range of batch elements.
+    #[inline]
+    fn view(&self, range: Range<usize>) -> &[f32] {
+        &self.data[range.start * self.count..range.end * self.count]
+    }
+
+    /// A mutable view over the specified range of batch elements.
+    #[inline]
+    fn view_mut(&mut self, range: Range<usize>) -> &mut [f32] {
+        &mut self.data[range.start * self.count..range.end * self.count]
+    }
+}
+
+const DEFAULT_CAPACITY: usize = 6;
+/// A scratch pad used during each inference call to avoid fragmented
+/// allocations and copying.
+pub struct ScratchPad {
+    pub(super) inputs: TVec<ScratchPadData>,
+    pub(super) outputs: TVec<ScratchPadData>,
+    pub(super) ids: Vec<u64>,
+    pub(super) batch_size: usize,
+    capacity: usize,
+}
+
+impl ScratchPad {
+    // TODO[TSolberg]: When switching to raw ModelAPI, fix this.
+    /// Construct a new scratchpad for the provided API.
+    pub fn new_for_shapes(
+        inputs: &[(String, Vec<usize>)],
+        outputs: &[(String, Vec<usize>)],
+    ) -> Self {
+        Self::new_with_size(inputs, outputs, DEFAULT_CAPACITY)
+    }
+
+    // TODO[TSolberg]: When switching to raw ModelAPI, fix this.
+    /// Construct a new scratchpad for the provided API with a specified default capacity.
+    pub fn new_with_size(
+        inputs: &[(String, Vec<usize>)],
+        outputs: &[(String, Vec<usize>)],
+        capacity: usize,
+    ) -> Self {
+        let inputs = inputs
+            .iter()
+            .map(|(name, shape)| {
+                let count = shape.iter().product();
+                ScratchPadData::new(name.to_owned(), count, capacity)
+            })
+            .collect();
+
+        let outputs = outputs
+            .iter()
+            .map(|(name, shape)| {
+                let count = shape.iter().product();
+                ScratchPadData::new(name.to_owned(), count, capacity)
+            })
+            .collect();
+
+        Self {
+            inputs,
+            outputs,
+            ids: vec![],
+            batch_size: 0,
+            capacity,
+        }
+    }
+
+    /// Prepare the next slot to store data for the provided id.
+    pub fn next(&mut self, id: u64) {
+        self.batch_size += 1;
+        self.ids.push(id);
+
+        if self.batch_size > self.capacity {
+            self.capacity *= 2;
+
+            for slot in &mut self.inputs {
+                slot.reserve(self.capacity);
+            }
+        }
+    }
+
+    /// Push data for the specific slot.
+    pub fn push(&mut self, slot: usize, data: Vec<f32>) {
+        self.inputs[slot]
+            .view_mut(self.batch_size - 1..self.batch_size)
+            .copy_from_slice(&data);
+    }
+
+    /// View the chunk starting at batch-element `offset` containing `size` elements.x
+    pub fn chunk(&mut self, offset: usize, size: usize) -> ScratchPadView {
+        let size = size.min(self.batch_size);
+        self.batch_size -= size;
+
+        ScratchPadView {
+            pad: self,
+            batch_range: offset..offset + size,
+        }
+    }
+
+    /// View of the specified `range` of input at location `slot`.
+    #[inline]
+    pub(crate) fn input_slot(&self, slot: usize, range: Range<usize>) -> &[f32] {
+        self.inputs[slot].view(range)
+    }
+
+    /// A mutable view of the specified `range` of input at location `slot`.
+    #[inline]
+    pub(crate) fn input_slot_mut(&mut self, slot: usize, range: Range<usize>) -> &mut [f32] {
+        self.inputs[slot].view_mut(range)
+    }
+
+    /// Retrieve the input name for `slot`.
+    #[inline]
+    pub(crate) fn input_name(&self, slot: usize) -> &str {
+        &self.inputs[slot].name
+    }
+
+    /// View of the specified `range` of output at location `slot`.
+    #[inline]
+    pub(crate) fn output_slot(&self, slot: usize, range: Range<usize>) -> &[f32] {
+        self.outputs[slot].view(range)
+    }
+
+    /// A mutable view of the specified `range` of output at location `slot`.
+    #[inline]
+    pub(crate) fn output_slot_mut(&mut self, slot: usize, range: Range<usize>) -> &mut [f32] {
+        self.outputs[slot].view_mut(range)
+    }
+
+    /// Retrieve the output name for `slot`.
+    #[inline]
+    pub(crate) fn output_name(&self, slot: usize) -> &str {
+        &self.outputs[slot].name
+    }
+}
+
+/// A view over a set of batch elements in a scratch pad.
+pub struct ScratchPadView<'a> {
+    pad: &'a mut ScratchPad,
+    batch_range: Range<usize>,
+}
+
+impl<'a> ScratchPadView<'a> {
+    /// View of the input at location `slot`.
+    pub fn input_slot(&self, slot: usize) -> &[f32] {
+        self.pad.input_slot(slot, self.batch_range.clone())
+    }
+
+    /// A mutable view of the input at location `slot`.
+    pub fn input_slot_mut(&mut self, slot: usize) -> &mut [f32] {
+        self.pad.input_slot_mut(slot, self.batch_range.clone())
+    }
+
+    /// Retrieve the input name for `slot`.
+    pub fn input_name(&self, slot: usize) -> &str {
+        self.pad.input_name(slot)
+    }
+
+    /// A mutable view of the data at input `slot`.
+    pub fn output_slot(&self, slot: usize) -> &[f32] {
+        self.pad.output_slot(slot, self.batch_range.clone())
+    }
+
+    /// A mutable view of the data at location `slot`.
+    pub fn output_slot_mut(&mut self, slot: usize) -> &mut [f32] {
+        self.pad.output_slot_mut(slot, self.batch_range.clone())
+    }
+
+    /// Retrieve the output name for `slot`.
+    pub fn output_name(&self, slot: usize) -> &str {
+        self.pad.output_name(slot)
+    }
+
+    /// The batch size of this view.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.batch_range.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod scratchppaddata {
+        use super::super::ScratchPadData;
+        #[test]
+        fn has_right_initial_space() {
+            let spd = ScratchPadData::new("epsilon".to_owned(), 24, 2);
+
+            assert_eq!(spd.count, 24);
+            assert_eq!(spd.data.len(), 48);
+            assert_eq!(spd.name, "epsilon");
+        }
+
+        #[test]
+        fn reserves_correct_size() {
+            let mut spd = ScratchPadData::new("epsilon".to_owned(), 24, 2);
+
+            spd.reserve(4);
+            assert_eq!(spd.count, 24);
+            assert_eq!(spd.data.len(), 24 * 4);
+        }
+
+        #[test]
+        fn views_correct_range() {
+            let mut spd = ScratchPadData::new("epsilon".to_owned(), 6, 4);
+
+            spd.reserve(4);
+            for idx in 0..24 {
+                spd.data[idx] = idx as f32;
+            }
+
+            assert_eq!(spd.view(0..1), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
+            assert_eq!(spd.view_mut(0..1), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
+            assert_eq!(spd.view(1..2), [6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+            assert_eq!(spd.view_mut(1..2), [6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+
+            assert_eq!(spd.view(3..4), [18.0, 19.0, 20.0, 21.0, 22.0, 23.0]);
+            assert_eq!(spd.view_mut(3..4), [18.0, 19.0, 20.0, 21.0, 22.0, 23.0]);
+        }
+    }
+}

--- a/crates/cervo-core/src/batcher/scratch.rs
+++ b/crates/cervo-core/src/batcher/scratch.rs
@@ -2,10 +2,6 @@
 // Copyright © 2022, Embark Studios, all rights reserved.
 // Created: 27 July 2022
 
-/*!
-
-*/
-
 use std::ops::Range;
 use tract_core::tract_data::TVec;
 

--- a/crates/cervo-core/src/batcher/wrapper.rs
+++ b/crates/cervo-core/src/batcher/wrapper.rs
@@ -1,0 +1,49 @@
+// Author: Tom Solberg <tom.solberg@embark-studios.com>
+// Copyright © 2022, Embark Studios, all rights reserved.
+// Created: 27 July 2022
+
+use super::Batcher;
+use crate::inferer::{Inferer, Response, State};
+use std::collections::HashMap;
+
+/// Wraps an inferer in a batching interface. This'll separate the
+/// data-insertion and execution, which generally improves
+/// performance.
+///
+/// Can be easily constructed using [InfererExt::into_batched](crate::prelude::InfererExt::into_batched).
+pub struct Batched<Inf: Inferer> {
+    inner: Inf,
+    batcher: Batcher,
+}
+
+impl<Inf> Batched<Inf>
+where
+    Inf: Inferer,
+{
+    /// Wrap the provided inferer.
+    pub fn wrap(inferer: Inf) -> Self {
+        let batcher = Batcher::new(&inferer);
+        Self {
+            batcher,
+            inner: inferer,
+        }
+    }
+
+    /// Insert a single element into the batch to include in the next execution.
+    pub fn push(&mut self, id: u64, state: State<'_>) -> anyhow::Result<()> {
+        self.batcher.push(id, state)
+    }
+
+    /// Insert a sequence of elements into the batch to include in the next execution.
+    pub fn extend<'a, Iter: IntoIterator<Item = (u64, State<'a>)>>(
+        &mut self,
+        states: Iter,
+    ) -> anyhow::Result<()> {
+        self.batcher.extend(states)
+    }
+
+    /// Execute the model on the data that has been enqueued previously.
+    pub fn execute(&mut self) -> anyhow::Result<HashMap<u64, Response>> {
+        self.batcher.execute(&mut self.inner)
+    }
+}

--- a/crates/cervo-core/src/epsilon.rs
+++ b/crates/cervo-core/src/epsilon.rs
@@ -181,7 +181,7 @@ where
 
     fn infer_batched<'pad, 'result>(
         &'result mut self,
-        batch: ScratchPadView<'pad>,
+        mut batch: ScratchPadView<'pad>,
     ) -> Result<BatchResponse<'result>, anyhow::Error> {
         let total_count = self.count * batch.len();
         let output = batch.slot_mut(self.index);

--- a/crates/cervo-core/src/epsilon.rs
+++ b/crates/cervo-core/src/epsilon.rs
@@ -6,10 +6,7 @@
 Utilities for filling noise inputs for an inference model.
 */
 
-use crate::{
-    batcher::ScratchPadView,
-    inferer::{BatchResponse, Inferer},
-};
+use crate::{batcher::ScratchPadView, inferer::Inferer};
 use anyhow::{bail, Result};
 use perchance::PerchanceContext;
 use rand::thread_rng;
@@ -180,9 +177,9 @@ where
     fn infer_raw<'pad, 'result>(
         &'result mut self,
         mut batch: ScratchPadView<'pad>,
-    ) -> Result<BatchResponse<'result>, anyhow::Error> {
+    ) -> Result<(), anyhow::Error> {
         let total_count = self.count * batch.len();
-        let output = batch.slot_mut(self.index);
+        let output = batch.input_slot_mut(self.index);
         self.generator.generate(total_count, output);
 
         self.inner.infer_raw(batch)

--- a/crates/cervo-core/src/epsilon.rs
+++ b/crates/cervo-core/src/epsilon.rs
@@ -41,9 +41,9 @@ impl ConstantGenerator {
 }
 
 impl NoiseGenerator for ConstantGenerator {
-    fn generate(&mut self, count: usize, out: &mut [f32]) {
-        for idx in 0..count {
-            out[idx] = self.value;
+    fn generate(&mut self, _count: usize, out: &mut [f32]) {
+        for o in out {
+            *o = self.value;
         }
     }
 }
@@ -75,9 +75,9 @@ impl Default for LowQualityNoiseGenerator {
 
 impl NoiseGenerator for LowQualityNoiseGenerator {
     /// Generate `count` random values.
-    fn generate(&mut self, count: usize, out: &mut [f32]) {
-        for idx in 0..count {
-            out[idx] = self.ctx.normal_f32();
+    fn generate(&mut self, _count: usize, out: &mut [f32]) {
+        for o in out {
+            *o = self.ctx.normal_f32();
         }
     }
 }
@@ -101,10 +101,10 @@ impl Default for HighQualityNoiseGenerator {
 
 impl NoiseGenerator for HighQualityNoiseGenerator {
     /// Generate `count` random values.
-    fn generate(&mut self, count: usize, out: &mut [f32]) {
+    fn generate(&mut self, _count: usize, out: &mut [f32]) {
         let mut rng = thread_rng();
-        for idx in 0..count {
-            out[idx] = self.normal_distribution.sample(&mut rng);
+        for o in out {
+            *o = self.normal_distribution.sample(&mut rng);
         }
     }
 }
@@ -174,10 +174,7 @@ where
         self.inner.select_batch_size(max_count)
     }
 
-    fn infer_raw<'pad, 'result>(
-        &'result mut self,
-        mut batch: ScratchPadView<'pad>,
-    ) -> Result<(), anyhow::Error> {
+    fn infer_raw(&mut self, mut batch: ScratchPadView) -> Result<(), anyhow::Error> {
         let total_count = self.count * batch.len();
         let output = batch.input_slot_mut(self.index);
         self.generator.generate(total_count, output);

--- a/crates/cervo-core/src/epsilon.rs
+++ b/crates/cervo-core/src/epsilon.rs
@@ -170,7 +170,7 @@ where
     T: Inferer,
     NG: NoiseGenerator,
 {
-    fn select_batch_size(&mut self, max_count: usize) -> usize {
+    fn select_batch_size(&self, max_count: usize) -> usize {
         self.inner.select_batch_size(max_count)
     }
 

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -48,7 +48,7 @@ pub use fixed::FixedBatchInferer;
 pub use memoizing::MemoizingDynamicInferer;
 
 use crate::{
-    batcher::{Batcher, ScratchPadView},
+    batcher::{Batched, Batcher, ScratchPadView},
     epsilon::{EpsilonInjector, NoiseGenerator},
 };
 
@@ -168,6 +168,11 @@ pub trait InfererExt: Inferer + Sized {
         key: &str,
     ) -> Result<EpsilonInjector<Self, G>> {
         EpsilonInjector::with_generator(self, generator, key)
+    }
+
+    /// Wrap in a batching interface.
+    fn into_batched(self) -> Batched<Self> {
+        Batched::wrap(self)
     }
 
     /// Execute the model on the provided batch of elements.

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -48,7 +48,7 @@ pub use fixed::FixedBatchInferer;
 pub use memoizing::MemoizingDynamicInferer;
 
 use crate::{
-    batcher::Batcher,
+    batcher::{Batcher, ScratchPadView},
     epsilon::{EpsilonInjector, NoiseGenerator},
 };
 
@@ -144,10 +144,10 @@ pub trait Inferer {
     fn select_batch_size(&mut self, max_count: usize) -> usize;
 
     /// Execute the model on the provided pre-batched data.
-    fn infer_batched<'a>(
-        &'a mut self,
-        batch: crate::inferer::Batch<'a>,
-    ) -> Result<BatchResponse<'a>, anyhow::Error>;
+    fn infer_batched<'pad, 'result>(
+        &'result mut self,
+        batch: ScratchPadView<'pad>,
+    ) -> Result<BatchResponse<'result>, anyhow::Error>;
 
     /// Retrieve the name and shapes of the model inputs.
     fn input_shapes(&self) -> &[(String, Vec<usize>)];

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -14,8 +14,10 @@ or the fragility of delegating input-building a layer up.
 
 ## Choosing an inferer
 
- <p style="background:rgba(255,181,77,0.16);padding:0.75em;">
-<strong>Note:</strong> Our inferer setup hs been iterated on since 2019, and we've gone through a few variants and tested a bunch of different infering setups. While important distinctions remain, it's important to know that on x86_64 platforms tract will use a kernel optimized for a batch size of 1 or 6 elements, picking whichever works best. Similar patterns exist on arm64. This is being worked on, but limits the performance gain from various batching strategies.</p>
+ <p style="background:rgba(255,181,77,0.16);padding:0.75em;"> <strong>Note:</strong> Our inferer setup hs been iterated
+on since 2019, and we've gone through a few variants and tested a bunch of different infering setups. See the rule of
+thumb for selecting an inferer below; but it is suggested to benchmark. While undocumented, you can use the code in the
+`perf-test` folder on GitHub to run various benchmarks.</p>
 
 Cervo currently provides four different inferers, two of which we've used historially (basic and fixed) and two based on
 newer tract functionalities that we've not tested as much yet. You'll find more detail on each page, but here comes a

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -89,34 +89,6 @@ impl<'a> Response<'a> {
 }
 
 /// A batch of data ordered by input slot
-pub struct Batch<'a> {
-    pub data: Vec<(&'a str, &'a [f32])>,
-    pub count: usize,
-}
-
-impl<'a> Batch<'a> {
-    /// Create a new empty batch to fill with data
-    pub fn empty() -> Self {
-        Self {
-            data: Default::default(),
-            count: 0,
-        }
-    }
-
-    pub fn insert(&mut self, name: &'a str, data: &'a [f32]) {
-        for (k, _v) in &mut self.data {
-            if *k != name {
-                continue;
-            }
-
-            panic!("double key??");
-        }
-
-        self.data.push((name, data));
-    }
-}
-
-/// A batch of data ordered by input slot
 pub struct BatchResponse<'a> {
     pub data: Vec<(&'a str, Vec<f32>)>,
 }

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -94,10 +94,7 @@ pub trait Inferer {
     fn select_batch_size(&mut self, max_count: usize) -> usize;
 
     /// Execute the model on the provided pre-batched data.
-    fn infer_raw<'pad, 'result>(
-        &'result mut self,
-        batch: ScratchPadView<'pad>,
-    ) -> Result<(), anyhow::Error>;
+    fn infer_raw(&mut self, batch: ScratchPadView) -> Result<(), anyhow::Error>;
 
     /// Retrieve the name and shapes of the model inputs.
     fn input_shapes(&self) -> &[(String, Vec<usize>)];

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -14,7 +14,7 @@ or the fragility of delegating input-building a layer up.
 
 ## Choosing an inferer
 
- <p style="background:rgba(255,181,77,0.16);padding:0.75em;"> <strong>Note:</strong> Our inferer setup hs been iterated
+ <p style="background:rgba(255,181,77,0.16);padding:0.75em;"> <strong>Note:</strong> Our inferer setup has been iterated
 on since 2019, and we've gone through a few variants and tested a bunch of different infering setups. See the rule of
 thumb for selecting an inferer below; but it is suggested to benchmark. While undocumented, you can use the code in the
 `perf-test` folder on GitHub to run various benchmarks.</p>

--- a/crates/cervo-core/src/inferer/basic.rs
+++ b/crates/cervo-core/src/inferer/basic.rs
@@ -65,9 +65,18 @@ impl BasicInferer {
 
         Ok(inputs)
     }
+}
 
-    fn infer_once(&mut self, obs: Batch) -> TractResult<BatchResponse> {
-        let inputs = self.build_inputs(obs)?;
+impl Inferer for BasicInferer {
+    fn select_batch_size(&mut self, _: usize) -> usize {
+        1
+    }
+
+    fn infer_batched<'input: 'output, 'output>(
+        &'input mut self,
+        batch: crate::inferer::Batch<'input>,
+    ) -> Result<crate::inferer::BatchResponse<'output>, anyhow::Error> {
+        let inputs = self.build_inputs(batch)?;
 
         // Run the optimized plan to get actions back!
         let result = self.model.run(inputs)?;
@@ -85,16 +94,6 @@ impl BasicInferer {
         }
 
         Ok(response)
-    }
-}
-
-impl Inferer for BasicInferer {
-    fn select_batch_size(&mut self, _: usize) -> usize {
-        1
-    }
-
-    fn infer_batched<'a>(&'a mut self, batch: Batch<'_>) -> Result<BatchResponse<'a>> {
-        self.infer_once(batch)
     }
 
     fn input_shapes(&self) -> &[(String, Vec<usize>)] {

--- a/crates/cervo-core/src/inferer/basic.rs
+++ b/crates/cervo-core/src/inferer/basic.rs
@@ -1,11 +1,11 @@
 /*!
 A basic unbatched inferer that doesn't require a lot of custom setup or management.
  */
-use super::{Batch, BatchResponse, Inferer};
+use super::{BatchResponse, Inferer};
 use crate::{batcher::ScratchPadView, model_api::ModelApi};
 use anyhow::Result;
-use tract_core::{ndarray::IntoDimension, prelude::*};
-use tract_hir::prelude::*;
+use tract_core::prelude::{tvec, TVec, Tensor, TractResult, TypedModel, TypedSimplePlan};
+use tract_hir::prelude::InferenceModel;
 
 use super::helpers;
 
@@ -72,7 +72,7 @@ impl Inferer for BasicInferer {
         1
     }
 
-    fn infer_batched<'pad, 'result>(
+    fn infer_raw<'pad, 'result>(
         &'result mut self,
         batch: ScratchPadView<'pad>,
     ) -> Result<BatchResponse<'result>, anyhow::Error> {

--- a/crates/cervo-core/src/inferer/basic.rs
+++ b/crates/cervo-core/src/inferer/basic.rs
@@ -68,7 +68,7 @@ impl BasicInferer {
 }
 
 impl Inferer for BasicInferer {
-    fn select_batch_size(&mut self, _: usize) -> usize {
+    fn select_batch_size(&self, _: usize) -> usize {
         1
     }
 

--- a/crates/cervo-core/src/inferer/basic.rs
+++ b/crates/cervo-core/src/inferer/basic.rs
@@ -58,7 +58,7 @@ impl BasicInferer {
             let total_count: usize = full_shape.iter().product();
             assert_eq!(total_count, obs.input_slot(idx).len());
 
-            let tensor = Tensor::from_shape(&full_shape, obs.input_slot(idx))?.into();
+            let tensor = Tensor::from_shape(&full_shape, obs.input_slot(idx))?;
 
             inputs.push(tensor);
         }
@@ -72,10 +72,7 @@ impl Inferer for BasicInferer {
         1
     }
 
-    fn infer_raw<'pad, 'result>(
-        &'result mut self,
-        mut pad: ScratchPadView<'pad>,
-    ) -> Result<(), anyhow::Error> {
+    fn infer_raw(&mut self, mut pad: ScratchPadView) -> Result<(), anyhow::Error> {
         let inputs = self.build_inputs(&pad)?;
 
         // Run the optimized plan to get actions back!

--- a/crates/cervo-core/src/inferer/dynamic.rs
+++ b/crates/cervo-core/src/inferer/dynamic.rs
@@ -84,7 +84,7 @@ impl DynamicInferer {
 }
 
 impl Inferer for DynamicInferer {
-    fn select_batch_size(&mut self, max_count: usize) -> usize {
+    fn select_batch_size(&self, max_count: usize) -> usize {
         max_count
     }
 

--- a/crates/cervo-core/src/inferer/dynamic.rs
+++ b/crates/cervo-core/src/inferer/dynamic.rs
@@ -1,7 +1,6 @@
-use super::{helpers, Inferer, Response, State};
+use super::{helpers, Batch, BatchResponse, Inferer};
 use crate::model_api::ModelApi;
-use anyhow::{Error, Result};
-use std::collections::HashMap;
+use anyhow::Result;
 use tract_core::prelude::*;
 use tract_hir::prelude::*;
 
@@ -59,72 +58,58 @@ impl DynamicInferer {
         Ok(this)
     }
 
-    fn build_inputs(&mut self, obs: Vec<State>) -> (TVec<Tensor>, usize) {
-        let size = obs.len();
-        let mut inputs = TVec::default();
-        let mut named_inputs = TVec::default();
+    fn build_inputs(&mut self, batch: Batch) -> Result<TVec<Tensor>> {
+        let size = batch.count;
 
-        for (name, shape) in &self.model_api.inputs {
+        let mut inputs = TVec::default();
+
+        for ((name, shape), (key, data)) in self.model_api.inputs.iter().zip(batch.data.into_iter())
+        {
+            assert_eq!(name, key);
+
             let mut full_shape = tvec![size];
             full_shape.extend_from_slice(shape);
 
-            let total_count = full_shape.iter().product();
-            named_inputs.push((name, (full_shape, Vec::with_capacity(total_count))));
-        }
+            let total_count: usize = full_shape.iter().product();
+            assert_eq!(total_count, data.len());
 
-        for observation in obs {
-            for (name, (_, store)) in named_inputs.iter_mut() {
-                store.extend_from_slice(&observation.data[*name]);
-            }
-        }
+            let shape = full_shape;
 
-        for (_, (shape, store)) in named_inputs {
-            let tensor = unsafe {
-                tract_ndarray::Array::from_shape_vec_unchecked(shape.into_vec(), store).into()
-            };
+            let tensor = Tensor::from_shape(&shape, data)?;
 
             inputs.push(tensor);
         }
 
-        (inputs, size)
-    }
-
-    fn infer_batched(&mut self, obs: Vec<State>, vec_out: &mut [Response]) -> TractResult<()> {
-        let (inputs, _count) = self.build_inputs(obs);
-
-        // Run the optimized plan to get actions back!
-        let result = self.model.run(inputs)?;
-
-        for (idx, (name, shape)) in self.model_api.outputs.iter().enumerate() {
-            for (response_idx, value) in result[idx]
-                .to_array_view::<f32>()?
-                .as_slice()
-                .unwrap()
-                .chunks(shape.iter().product())
-                .map(|value| value.to_vec())
-                .enumerate()
-            {
-                vec_out[response_idx].data.insert(name.to_owned(), value);
-            }
-        }
-
-        Ok(())
+        Ok(inputs)
     }
 }
 
 impl Inferer for DynamicInferer {
-    fn infer(
-        &mut self,
-        observations: HashMap<u64, State>,
-    ) -> Result<HashMap<u64, Response>, Error> {
-        let mut responses: Vec<Response> = vec![Response::default(); observations.len()];
-        let (ids, obs): (Vec<_>, Vec<_>) = observations.into_iter().unzip();
+    fn select_batch_size(&mut self, max_count: usize) -> usize {
+        max_count
+    }
 
-        self.infer_batched(obs, &mut responses)?;
+    fn infer_batched<'a, 'b>(
+        &'a mut self,
+        batch: crate::inferer::Batch<'b>,
+    ) -> Result<BatchResponse<'a>, anyhow::Error> {
+        let inputs = self.build_inputs(batch)?;
 
-        let results: HashMap<u64, Response> = ids.into_iter().zip(responses.drain(..)).collect();
+        // Run the optimized plan to get actions back!
+        let result = self.model.run(inputs)?;
 
-        Ok(results)
+        let mut response = BatchResponse::empty();
+        for (idx, (name, _)) in self.model_api.outputs.iter().enumerate() {
+            let value = result[idx]
+                .to_array_view::<f32>()?
+                .as_slice()
+                .unwrap()
+                .to_owned();
+
+            response.insert(name, value);
+        }
+
+        Ok(response)
     }
 
     fn input_shapes(&self) -> &[(String, Vec<usize>)] {

--- a/crates/cervo-core/src/inferer/dynamic.rs
+++ b/crates/cervo-core/src/inferer/dynamic.rs
@@ -88,10 +88,7 @@ impl Inferer for DynamicInferer {
         max_count
     }
 
-    fn infer_raw<'pad, 'result>(
-        &'result mut self,
-        mut pad: ScratchPadView<'pad>,
-    ) -> Result<(), anyhow::Error> {
+    fn infer_raw(&mut self, mut pad: ScratchPadView) -> Result<(), anyhow::Error> {
         let inputs = self.build_inputs(&pad)?;
 
         // Run the optimized plan to get actions back!

--- a/crates/cervo-core/src/inferer/dynamic.rs
+++ b/crates/cervo-core/src/inferer/dynamic.rs
@@ -1,8 +1,8 @@
-use super::{helpers, Batch, BatchResponse, Inferer};
+use super::{helpers, BatchResponse, Inferer};
 use crate::{batcher::ScratchPadView, model_api::ModelApi};
 use anyhow::Result;
-use tract_core::prelude::*;
-use tract_hir::prelude::*;
+use tract_core::prelude::{tvec, TVec, Tensor, TractResult, TypedModel, TypedSimplePlan};
+use tract_hir::prelude::InferenceModel;
 
 /// The dynamic inferer hits a spot between the raw simplicity of a [`crate::prelude::BasicInferer`] and the spikiness
 /// of a [`crate::prelude::MemoizingDynamicInferer`]. Instead of explicitly concretizing models and caching them, it
@@ -88,7 +88,7 @@ impl Inferer for DynamicInferer {
         max_count
     }
 
-    fn infer_batched<'pad, 'result>(
+    fn infer_raw<'pad, 'result>(
         &'result mut self,
         batch: ScratchPadView<'pad>,
     ) -> Result<BatchResponse<'result>, anyhow::Error> {

--- a/crates/cervo-core/src/inferer/fixed.rs
+++ b/crates/cervo-core/src/inferer/fixed.rs
@@ -1,9 +1,8 @@
-use super::{helpers, Batch, BatchResponse, Inferer};
+use super::{helpers, BatchResponse, Inferer};
 use crate::{batcher::ScratchPadView, model_api::ModelApi};
 use anyhow::{Context, Result};
-
-use tract_core::prelude::*;
-use tract_hir::prelude::*;
+use tract_core::prelude::{tvec, TVec, Tensor, TractResult, TypedModel, TypedSimplePlan};
+use tract_hir::prelude::InferenceModel;
 
 /// A reliable batched inferer that is a good fit if you know how much data you'll have and want stable performance.
 ///
@@ -85,7 +84,7 @@ impl FixedBatchInferer {
 }
 
 impl Inferer for FixedBatchInferer {
-    fn infer_batched<'pad, 'result>(
+    fn infer_raw<'pad, 'result>(
         &'result mut self,
         batch: ScratchPadView<'pad>,
     ) -> Result<BatchResponse<'result>, anyhow::Error> {

--- a/crates/cervo-core/src/inferer/fixed.rs
+++ b/crates/cervo-core/src/inferer/fixed.rs
@@ -94,7 +94,7 @@ impl Inferer for FixedBatchInferer {
         plan.execute(batch, &self.model_api)
     }
 
-    fn select_batch_size(&mut self, max_count: usize) -> usize {
+    fn select_batch_size(&self, max_count: usize) -> usize {
         // Find the smallest batch size below or equal to max_count
         self.models
             .iter()

--- a/crates/cervo-core/src/inferer/fixed.rs
+++ b/crates/cervo-core/src/inferer/fixed.rs
@@ -85,7 +85,10 @@ impl FixedBatchInferer {
 }
 
 impl Inferer for FixedBatchInferer {
-    fn infer_batched<'a>(&'a mut self, batch: Batch<'_>) -> Result<BatchResponse<'a>> {
+    fn infer_batched<'input: 'output, 'output>(
+        &'input mut self,
+        batch: crate::inferer::Batch<'input>,
+    ) -> Result<BatchResponse<'output>, anyhow::Error> {
         let plan = self
             .models
             .iter_mut()

--- a/crates/cervo-core/src/inferer/fixed.rs
+++ b/crates/cervo-core/src/inferer/fixed.rs
@@ -84,10 +84,7 @@ impl FixedBatchInferer {
 }
 
 impl Inferer for FixedBatchInferer {
-    fn infer_raw<'pad, 'result>(
-        &'result mut self,
-        batch: ScratchPadView<'pad>,
-    ) -> Result<(), anyhow::Error> {
+    fn infer_raw(&mut self, batch: ScratchPadView) -> Result<(), anyhow::Error> {
         let plan = self
             .models
             .iter_mut()

--- a/crates/cervo-core/src/inferer/fixed.rs
+++ b/crates/cervo-core/src/inferer/fixed.rs
@@ -1,7 +1,7 @@
-use super::{helpers, Inferer, Response, State};
+use super::{helpers, Batch, BatchResponse, Inferer};
 use crate::model_api::ModelApi;
-use anyhow::{Error, Result};
-use std::collections::HashMap;
+use anyhow::{Context, Result};
+
 use tract_core::prelude::*;
 use tract_hir::prelude::*;
 
@@ -82,40 +82,26 @@ impl FixedBatchInferer {
 
         Ok(Self { models, model_api })
     }
-
-    fn infer_batched(&mut self, obs: Vec<State>, vec_out: &mut [Response]) -> TractResult<()> {
-        let mut offset = 0;
-        let mut count = obs.len();
-        let mut obs = obs.into_iter();
-
-        for plan in &mut self.models {
-            while (count / plan.size) > 0 {
-                plan.execute(&mut obs, &self.model_api, &mut vec_out[offset..])?;
-                count -= plan.size;
-                offset += plan.size;
-            }
-            if count == 0 {
-                break;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl Inferer for FixedBatchInferer {
-    fn infer(
-        &mut self,
-        observations: HashMap<u64, State>,
-    ) -> Result<HashMap<u64, Response>, Error> {
-        let mut responses: Vec<Response> = vec![Response::default(); observations.len()];
-        let (ids, obs): (Vec<_>, Vec<_>) = observations.into_iter().unzip();
+    fn infer_batched<'a>(&'a mut self, batch: Batch<'_>) -> Result<BatchResponse<'a>> {
+        let plan = self
+            .models
+            .iter_mut()
+            .find(|plan| plan.size == batch.count)
+            .with_context(|| anyhow::anyhow!("looking for a plan with size {:?}", batch.count))?;
 
-        self.infer_batched(obs, &mut responses)?;
+        plan.execute(batch, &self.model_api)
+    }
 
-        let results: HashMap<u64, Response> = ids.into_iter().zip(responses.drain(..)).collect();
-
-        Ok(results)
+    fn select_batch_size(&mut self, max_count: usize) -> usize {
+        // Find the smallest batch size below or equal to max_count
+        self.models
+            .iter()
+            .map(|plan| plan.size)
+            .find(|size| *size <= max_count)
+            .unwrap()
     }
 
     fn input_shapes(&self) -> &[(String, Vec<usize>)] {
@@ -133,63 +119,58 @@ struct BatchedModel {
 }
 
 impl BatchedModel {
-    fn build_inputs<It: std::iter::Iterator<Item = State>>(
-        &mut self,
-        obs: &mut It,
-        model_api: &ModelApi,
-    ) -> TVec<Tensor> {
+    fn build_inputs(&mut self, batch: Batch, model_api: &ModelApi) -> Result<TVec<Tensor>> {
+        assert_eq!(batch.count, self.size);
         let size = self.size;
-        let mut inputs = TVec::default();
-        let mut named_inputs = TVec::default();
 
-        for (name, shape) in &model_api.inputs {
+        let mut inputs = TVec::default();
+
+        for ((name, shape), (key, data)) in model_api.inputs.iter().zip(batch.data.into_iter()) {
+            assert_eq!(name, key);
+
             let mut full_shape = tvec![size];
             full_shape.extend_from_slice(shape);
 
-            let total_count = full_shape.iter().product();
-            named_inputs.push((name, (full_shape, Vec::with_capacity(total_count))));
-        }
+            let total_count: usize = full_shape.iter().product();
+            assert_eq!(
+                total_count,
+                data.len(),
+                "mismatched number of features: expected {:?}, got {:?} for shape {:?}",
+                total_count,
+                data.len(),
+                full_shape
+            );
 
-        for observation in obs.take(size) {
-            for (name, (_, store)) in named_inputs.iter_mut() {
-                store.extend_from_slice(&observation.data[*name]);
-            }
-        }
+            let shape = full_shape;
 
-        for (_, (shape, store)) in named_inputs {
-            let tensor = unsafe {
-                tract_ndarray::Array::from_shape_vec_unchecked(shape.into_vec(), store).into()
-            };
+            let tensor = Tensor::from_shape(&shape, data)?;
 
             inputs.push(tensor);
         }
 
-        inputs
+        Ok(inputs)
     }
 
-    fn execute<It: std::iter::Iterator<Item = State>>(
+    fn execute<'a>(
         &mut self,
-        observations: &mut It,
-        model_api: &ModelApi,
-        vec_out: &mut [Response],
-    ) -> Result<()> {
-        let inputs = self.build_inputs(observations, model_api);
+        observations: Batch,
+        model_api: &'a ModelApi,
+    ) -> Result<BatchResponse<'a>> {
+        let inputs = self.build_inputs(observations, model_api)?;
 
         let result = self.plan.run(inputs)?;
 
-        for (idx, (name, shape)) in model_api.outputs.iter().enumerate() {
-            for (response_idx, value) in result[idx]
+        let mut output = BatchResponse::empty();
+        for (idx, (name, _)) in model_api.outputs.iter().enumerate() {
+            let value = result[idx]
                 .to_array_view::<f32>()?
                 .as_slice()
                 .unwrap()
-                .chunks(shape.iter().product())
-                .map(|value| value.to_vec())
-                .enumerate()
-            {
-                vec_out[response_idx].data.insert(name.to_owned(), value);
-            }
+                .to_owned();
+
+            output.insert(name, value);
         }
 
-        Ok(())
+        Ok(output)
     }
 }

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -137,10 +137,7 @@ impl Inferer for MemoizingDynamicInferer {
         max_count
     }
 
-    fn infer_raw<'pad, 'result>(
-        &'result mut self,
-        mut pad: ScratchPadView<'pad>,
-    ) -> Result<(), anyhow::Error> {
+    fn infer_raw(&mut self, mut pad: ScratchPadView) -> Result<(), anyhow::Error> {
         let count = pad.len();
         let inputs = self.build_inputs(&pad)?;
 

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -1,6 +1,6 @@
-use super::{helpers, Inferer, Response, State};
+use super::{helpers, Batch, BatchResponse, Inferer};
 use crate::model_api::ModelApi;
-use anyhow::{Error, Result};
+use anyhow::Result;
 use std::collections::{hash_map::Entry, HashMap};
 use tract_core::prelude::*;
 use tract_hir::prelude::*;
@@ -92,34 +92,29 @@ impl MemoizingDynamicInferer {
         Ok(this)
     }
 
-    fn build_inputs(&mut self, obs: Vec<State>) -> (TVec<Tensor>, usize) {
-        let size = obs.len();
-        let mut inputs = TVec::default();
-        let mut named_inputs = TVec::default();
+    fn build_inputs(&mut self, batch: Batch) -> Result<TVec<Tensor>> {
+        let size = batch.count;
 
-        for (name, shape) in &self.model_api.inputs {
+        let mut inputs = TVec::default();
+
+        for ((name, shape), (key, data)) in self.model_api.inputs.iter().zip(batch.data.into_iter())
+        {
+            assert_eq!(name, key);
+
             let mut full_shape = tvec![size];
             full_shape.extend_from_slice(shape);
 
-            let total_count = full_shape.iter().product();
-            named_inputs.push((name, (full_shape, Vec::with_capacity(total_count))));
-        }
+            let total_count: usize = full_shape.iter().product();
+            assert_eq!(total_count, data.len());
 
-        for observation in obs {
-            for (name, (_, store)) in named_inputs.iter_mut() {
-                store.extend_from_slice(&observation.data[*name]);
-            }
-        }
+            let shape = full_shape;
 
-        for (_, (shape, store)) in named_inputs {
-            let tensor = unsafe {
-                tract_ndarray::Array::from_shape_vec_unchecked(shape.into_vec(), store).into()
-            };
+            let tensor = Tensor::from_shape(&shape, data)?;
 
             inputs.push(tensor);
         }
 
-        (inputs, size)
+        Ok(inputs)
     }
 
     fn get_concrete_model(&mut self, size: usize) -> Result<&TypedSimplePlan<TypedModel>> {
@@ -136,43 +131,31 @@ impl MemoizingDynamicInferer {
 
         Ok(&self.model_cache[&size])
     }
-
-    fn infer_batched(&mut self, obs: Vec<State>, vec_out: &mut [Response]) -> TractResult<()> {
-        let (inputs, count) = self.build_inputs(obs);
-
-        // Run the optimized plan to get actions back!
-        let result = self.get_concrete_model(count)?.run(inputs)?;
-
-        for (idx, (name, shape)) in self.model_api.outputs.iter().enumerate() {
-            for (response_idx, value) in result[idx]
-                .to_array_view::<f32>()?
-                .as_slice()
-                .unwrap()
-                .chunks(shape.iter().product())
-                .map(|value| value.to_vec())
-                .enumerate()
-            {
-                vec_out[response_idx].data.insert(name.to_owned(), value);
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl Inferer for MemoizingDynamicInferer {
-    fn infer(
-        &mut self,
-        observations: HashMap<u64, State>,
-    ) -> Result<HashMap<u64, Response>, Error> {
-        let mut responses: Vec<Response> = vec![Response::default(); observations.len()];
-        let (ids, obs): (Vec<_>, Vec<_>) = observations.into_iter().unzip();
+    fn select_batch_size(&mut self, max_count: usize) -> usize {
+        max_count
+    }
 
-        self.infer_batched(obs, &mut responses)?;
+    fn infer_batched<'a>(&'a mut self, batch: Batch) -> Result<BatchResponse<'a>> {
+        let count = batch.count;
+        let inputs = self.build_inputs(batch)?;
 
-        let results: HashMap<u64, Response> = ids.into_iter().zip(responses.drain(..)).collect();
+        let result = self.get_concrete_model(count)?.run(inputs)?;
 
-        Ok(results)
+        let mut response = BatchResponse::empty();
+        for (idx, (name, _)) in self.model_api.outputs.iter().enumerate() {
+            let value = result[idx]
+                .to_array_view::<f32>()?
+                .as_slice()
+                .unwrap()
+                .to_owned();
+
+            response.insert(name, value);
+        }
+
+        Ok(response)
     }
 
     fn input_shapes(&self) -> &[(String, Vec<usize>)] {

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -1,4 +1,4 @@
-use super::{helpers, BatchResponse, Inferer};
+use super::{helpers, Inferer};
 use crate::{batcher::ScratchPadView, model_api::ModelApi};
 use anyhow::Result;
 use std::collections::{hash_map::Entry, HashMap};
@@ -92,23 +92,23 @@ impl MemoizingDynamicInferer {
         Ok(this)
     }
 
-    fn build_inputs(&mut self, batch: ScratchPadView) -> Result<TVec<Tensor>> {
+    fn build_inputs(&mut self, batch: &ScratchPadView) -> Result<TVec<Tensor>> {
         let size = batch.len();
 
         let mut inputs = TVec::default();
 
         for (idx, (name, shape)) in self.model_api.inputs.iter().enumerate() {
-            assert_eq!(name, batch.slot_name(idx));
+            assert_eq!(name, batch.input_name(idx));
 
             let mut full_shape = tvec![size];
             full_shape.extend_from_slice(shape);
 
             let total_count: usize = full_shape.iter().product();
-            assert_eq!(total_count, batch.slot(idx).len());
+            assert_eq!(total_count, batch.input_slot(idx).len());
 
             let shape = full_shape;
 
-            let tensor = Tensor::from_shape(&shape, batch.slot(idx))?;
+            let tensor = Tensor::from_shape(&shape, batch.input_slot(idx))?;
 
             inputs.push(tensor);
         }
@@ -139,25 +139,19 @@ impl Inferer for MemoizingDynamicInferer {
 
     fn infer_raw<'pad, 'result>(
         &'result mut self,
-        batch: ScratchPadView<'pad>,
-    ) -> Result<BatchResponse<'result>, anyhow::Error> {
-        let count = batch.len();
-        let inputs = self.build_inputs(batch)?;
+        mut pad: ScratchPadView<'pad>,
+    ) -> Result<(), anyhow::Error> {
+        let count = pad.len();
+        let inputs = self.build_inputs(&pad)?;
 
         let result = self.get_concrete_model(count)?.run(inputs)?;
 
-        let mut response = BatchResponse::empty();
-        for (idx, (name, _)) in self.model_api.outputs.iter().enumerate() {
-            let value = result[idx]
-                .to_array_view::<f32>()?
-                .as_slice()
-                .unwrap()
-                .to_owned();
-
-            response.insert(name, value);
+        for idx in 0..self.model_api.outputs.len() {
+            let value = result[idx].as_slice::<f32>()?;
+            pad.output_slot_mut(idx).copy_from_slice(value);
         }
 
-        Ok(response)
+        Ok(())
     }
 
     fn input_shapes(&self) -> &[(String, Vec<usize>)] {

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -133,7 +133,7 @@ impl MemoizingDynamicInferer {
 }
 
 impl Inferer for MemoizingDynamicInferer {
-    fn select_batch_size(&mut self, max_count: usize) -> usize {
+    fn select_batch_size(&self, max_count: usize) -> usize {
         max_count
     }
 

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -1,4 +1,4 @@
-use super::{helpers, Batch, BatchResponse, Inferer};
+use super::{helpers, BatchResponse, Inferer};
 use crate::{batcher::ScratchPadView, model_api::ModelApi};
 use anyhow::Result;
 use std::collections::{hash_map::Entry, HashMap};
@@ -137,7 +137,7 @@ impl Inferer for MemoizingDynamicInferer {
         max_count
     }
 
-    fn infer_batched<'pad, 'result>(
+    fn infer_raw<'pad, 'result>(
         &'result mut self,
         batch: ScratchPadView<'pad>,
     ) -> Result<BatchResponse<'result>, anyhow::Error> {

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -138,7 +138,10 @@ impl Inferer for MemoizingDynamicInferer {
         max_count
     }
 
-    fn infer_batched<'a>(&'a mut self, batch: Batch) -> Result<BatchResponse<'a>> {
+    fn infer_batched<'input: 'output, 'output>(
+        &'input mut self,
+        batch: crate::inferer::Batch<'input>,
+    ) -> Result<BatchResponse<'output>, anyhow::Error> {
         let count = batch.count;
         let inputs = self.build_inputs(batch)?;
 

--- a/crates/cervo-core/src/lib.rs
+++ b/crates/cervo-core/src/lib.rs
@@ -9,12 +9,14 @@ simplify our workflows.
 pub use tract_core;
 pub use tract_hir;
 
+pub mod batcher;
 pub mod epsilon;
 pub mod inferer;
 mod model_api;
 
 /// Most core utilities are re-exported here.
 pub mod prelude {
+    pub use super::batcher::Batcher;
     pub use super::epsilon::{
         EpsilonInjector, HighQualityNoiseGenerator, LowQualityNoiseGenerator, NoiseGenerator,
     };

--- a/crates/cervo-core/src/lib.rs
+++ b/crates/cervo-core/src/lib.rs
@@ -16,7 +16,7 @@ mod model_api;
 
 /// Most core utilities are re-exported here.
 pub mod prelude {
-    pub use super::batcher::Batcher;
+    pub use super::batcher::{Batched, Batcher};
     pub use super::epsilon::{
         EpsilonInjector, HighQualityNoiseGenerator, LowQualityNoiseGenerator, NoiseGenerator,
     };

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -1,5 +1,5 @@
 // Author: Tom Solberg <tom.solberg@embark-studios.com>
-// Copyright © 2022, Tom Solberg, all rights reserved.
+// Copyright © 2022, Embark Studios, all rights reserved.
 // Created: 27 July 2022
 
 /*!

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -25,7 +25,7 @@ where
     B: FnMut(usize) -> usize,
     R: FnMut(cervo_core::batcher::ScratchPadView) -> anyhow::Result<(), anyhow::Error>,
 {
-    fn select_batch_size(&mut self, max_count: usize) -> usize {
+    fn select_batch_size(&self, max_count: usize) -> usize {
         (self.batch_size)(max_count)
     }
 

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -1,0 +1,234 @@
+// Author: Tom Solberg <tom.solberg@embark-studios.com>
+// Copyright © 2022, Tom Solberg, all rights reserved.
+// Created: 27 July 2022
+
+/*!
+
+*/
+
+use std::collections::HashMap;
+
+use cervo_core::prelude::{Batcher, Inferer, InfererExt, State};
+
+struct TestInferer<
+    B: FnMut(usize) -> usize,
+    R: FnMut(cervo_core::batcher::ScratchPadView) -> anyhow::Result<(), anyhow::Error>,
+> {
+    batch_size: B,
+    raw: R,
+    in_shapes: Vec<(String, Vec<usize>)>,
+    out_shapes: Vec<(String, Vec<usize>)>,
+}
+
+impl<B, R> Inferer for TestInferer<B, R>
+where
+    B: FnMut(usize) -> usize,
+    R: FnMut(cervo_core::batcher::ScratchPadView) -> anyhow::Result<(), anyhow::Error>,
+{
+    fn select_batch_size(&mut self, max_count: usize) -> usize {
+        (self.batch_size)(max_count)
+    }
+
+    fn infer_raw(
+        &mut self,
+        batch: cervo_core::batcher::ScratchPadView,
+    ) -> anyhow::Result<(), anyhow::Error> {
+        (self.raw)(batch)
+    }
+
+    fn input_shapes(&self) -> &[(String, Vec<usize>)] {
+        &self.in_shapes
+    }
+
+    fn output_shapes(&self) -> &[(String, Vec<usize>)] {
+        &self.out_shapes
+    }
+}
+
+#[test]
+fn test_construct_wrapper() {
+    let inf = TestInferer {
+        batch_size: |_| 3,
+        raw: |_| Ok(()),
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let _batched = inf.into_batched();
+}
+
+#[test]
+fn test_construct_loose() {
+    let inf = TestInferer {
+        batch_size: |_| 3,
+        raw: |_| Ok(()),
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let _batcher = Batcher::new(&inf);
+}
+
+#[test]
+fn test_push_basic() {
+    let mut call_count = 0;
+    let mut inf = TestInferer {
+        batch_size: |_| 1,
+        raw: |b| {
+            call_count += 1;
+            assert_eq!(b.len(), 1);
+            assert_eq!(b.input_slot(0).len(), 11);
+            Ok(())
+        },
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let mut batcher = Batcher::new(&inf);
+
+    for id in 0..2 {
+        let mut s = State::empty();
+        s.data.insert("first", vec![0.0; 11]);
+        batcher.push(id, s).unwrap();
+    }
+
+    batcher.execute(&mut inf).unwrap();
+    assert_eq!(call_count, 2);
+}
+
+#[test]
+fn test_push_two() {
+    let mut call_count = 0;
+    let mut inf = TestInferer {
+        batch_size: |_| 2,
+        raw: |b| {
+            call_count += 1;
+            assert_eq!(b.len(), 2);
+            assert_eq!(b.input_slot(0).len(), 22);
+            Ok(())
+        },
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let mut batcher = Batcher::new(&inf);
+
+    for id in 0..4 {
+        let mut s = State::empty();
+        s.data.insert("first", vec![0.0; 11]);
+        batcher.push(id, s).unwrap();
+    }
+
+    batcher.execute(&mut inf).unwrap();
+    assert_eq!(call_count, 2);
+}
+
+#[test]
+fn test_extend_single() {
+    let mut call_count = 0;
+    let mut inf = TestInferer {
+        batch_size: |_| 1,
+        raw: |b| {
+            call_count += 1;
+            assert_eq!(b.len(), 1);
+            assert_eq!(b.input_slot(0).len(), 11);
+            Ok(())
+        },
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let mut batcher = Batcher::new(&inf);
+
+    let mut batch: HashMap<u64, State<'static>> = HashMap::default();
+
+    let first = &"first";
+    for id in 0..2 {
+        let mut s = State::empty();
+        s.data.insert(&first, vec![0.0; 11]);
+        batch.insert(id, s);
+    }
+
+    batcher.extend(batch).unwrap();
+    batcher.execute(&mut inf).unwrap();
+    assert_eq!(call_count, 2);
+}
+
+#[test]
+fn test_extend_double() {
+    let mut call_count = 0;
+    let mut inf = TestInferer {
+        batch_size: |_| 2,
+        raw: |b| {
+            call_count += 1;
+            assert_eq!(b.len(), 2);
+            assert_eq!(b.input_slot(0).len(), 22);
+            Ok(())
+        },
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let mut batcher = Batcher::new(&inf);
+
+    let mut batch: HashMap<u64, State<'static>> = HashMap::default();
+
+    let first = &"first";
+    for id in 0..4 {
+        let mut s = State::empty();
+        s.data.insert(&first, vec![0.0; 11]);
+        batch.insert(id, s);
+    }
+
+    batcher.extend(batch).unwrap();
+    batcher.execute(&mut inf).unwrap();
+    assert_eq!(call_count, 2);
+}
+
+#[test]
+fn test_values() {
+    let mut call_count = 0;
+    let mut inf = TestInferer {
+        batch_size: |_| 2,
+        raw: |mut b| {
+            assert_eq!(b.len(), 2);
+            assert_eq!(b.input_slot(0).len(), 22);
+            assert_eq!(
+                b.input_slot(0),
+                (11 * (call_count * b.len())..(call_count * b.len() + b.len()) * 11)
+                    .map(|i| i as f32)
+                    .collect::<Vec<_>>()
+            );
+            let l = b.len();
+            let out = b.output_slot_mut(0);
+            for (i, o) in out.iter_mut().enumerate() {
+                *o = (call_count * l) as f32 + i as f32 / 11.0;
+            }
+            call_count += 1;
+            Ok(())
+        },
+        in_shapes: vec![("first".to_owned(), vec![11])],
+        out_shapes: vec![("out".to_owned(), vec![11])],
+    };
+
+    let mut batcher = Batcher::new(&inf);
+
+    let first = &"first";
+    for id in 0..4 {
+        let mut s = State::empty();
+        s.data
+            .insert(&first, (11 * id..(id + 1) * 11).map(|i| i as f32).collect());
+
+        batcher.push(id, s).unwrap();
+    }
+
+    let r = batcher.execute(&mut inf).unwrap();
+    assert_eq!(r.len(), 4);
+    dbg!(&r);
+    for (id, vals) in r {
+        assert_eq!(vals.data["out"].len(), 11);
+        assert_eq!(vals.data["out"][0], id as f32);
+    }
+
+    assert_eq!(call_count, 2);
+}

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -2,10 +2,6 @@
 // Copyright © 2022, Embark Studios, all rights reserved.
 // Created: 27 July 2022
 
-/*!
-
-*/
-
 use std::collections::HashMap;
 
 use cervo_core::prelude::{Batcher, Inferer, InfererExt, State};

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -145,7 +145,7 @@ fn test_extend_single() {
     let first = &"first";
     for id in 0..2 {
         let mut s = State::empty();
-        s.data.insert(&first, vec![0.0; 11]);
+        s.data.insert(first, vec![0.0; 11]);
         batch.insert(id, s);
     }
 
@@ -173,10 +173,10 @@ fn test_extend_double() {
 
     let mut batch: HashMap<u64, State<'static>> = HashMap::default();
 
-    let first = &"first";
+    let first = "first";
     for id in 0..4 {
         let mut s = State::empty();
-        s.data.insert(&first, vec![0.0; 11]);
+        s.data.insert(first, vec![0.0; 11]);
         batch.insert(id, s);
     }
 
@@ -217,7 +217,7 @@ fn test_values() {
     for id in 0..4 {
         let mut s = State::empty();
         s.data
-            .insert(&first, (11 * id..(id + 1) * 11).map(|i| i as f32).collect());
+            .insert(first, (11 * id..(id + 1) * 11).map(|i| i as f32).collect());
 
         batcher.push(id, s).unwrap();
     }

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use cervo_core::prelude::{Batcher, Inferer, InfererExt, State};
 
 struct TestInferer<
-    B: FnMut(usize) -> usize,
+    B: Fn(usize) -> usize,
     R: FnMut(cervo_core::batcher::ScratchPadView) -> anyhow::Result<(), anyhow::Error>,
 > {
     batch_size: B,
@@ -22,7 +22,7 @@ struct TestInferer<
 
 impl<B, R> Inferer for TestInferer<B, R>
 where
-    B: FnMut(usize) -> usize,
+    B: Fn(usize) -> usize,
     R: FnMut(cervo_core::batcher::ScratchPadView) -> anyhow::Result<(), anyhow::Error>,
 {
     fn select_batch_size(&self, max_count: usize) -> usize {

--- a/crates/cervo-nnef/tests/helpers.rs
+++ b/crates/cervo-nnef/tests/helpers.rs
@@ -27,7 +27,7 @@ pub fn build_inputs_from_desc(count: u64, inputs: &[(String, Vec<usize>)]) -> Ha
                 State {
                     data: inputs
                         .iter()
-                        .map(|(key, count)| ((*key).clone(), vec![0.0; count.iter().product()]))
+                        .map(|(key, count)| (key.as_str(), vec![0.0; count.iter().product()]))
                         .collect(),
                 },
             )

--- a/crates/cervo-nnef/tests/infer-complex.rs
+++ b/crates/cervo-nnef/tests/infer-complex.rs
@@ -2,7 +2,7 @@
 // Copyright © 2022, Embark Studios AB, all rights reserved.
 // Created: 10 May 2022
 
-use cervo_core::prelude::{EpsilonInjector, Inferer};
+use cervo_core::prelude::{EpsilonInjector, Inferer, InfererExt};
 
 #[path = "./helpers.rs"]
 mod helpers;
@@ -17,8 +17,9 @@ fn test_infer_once_complex() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(1, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(1, &shapes);
+    let result = instance.infer_batch(observations);
 
     assert!(result.is_ok());
     let result = result.unwrap();
@@ -38,8 +39,9 @@ fn test_infer_once_complex_batched() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(10, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(10, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();
@@ -59,8 +61,9 @@ fn test_infer_once_complex_batched_not_loaded() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(10, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(10, &shapes);
+    let result = instance.infer_batch(observations);
     eprintln!("result {:?}", result);
     assert!(result.is_ok());
 
@@ -81,8 +84,9 @@ fn test_infer_once_complex_fixed_batch() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(7, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(7, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();

--- a/crates/cervo-nnef/tests/infer-simple.rs
+++ b/crates/cervo-nnef/tests/infer-simple.rs
@@ -5,7 +5,7 @@
 /*!
 
 */
-use cervo_core::prelude::{EpsilonInjector, Inferer};
+use cervo_core::prelude::{EpsilonInjector, Inferer, InfererExt};
 
 #[path = "./helpers.rs"]
 mod helpers;
@@ -16,9 +16,9 @@ fn test_infer_once_simple() {
     let instance = cervo_nnef::builder(&mut reader).build_basic().unwrap();
     let mut instance = EpsilonInjector::wrap(instance, "epsilon").unwrap();
 
-    let observations = helpers::build_inputs_from_desc(1, instance.input_shapes());
-
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(1, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();

--- a/crates/cervo-onnx/tests/helpers.rs
+++ b/crates/cervo-onnx/tests/helpers.rs
@@ -28,7 +28,7 @@ pub fn build_inputs_from_desc(count: u64, inputs: &[(String, Vec<usize>)]) -> Ha
                 State {
                     data: inputs
                         .iter()
-                        .map(|(key, count)| ((*key).clone(), vec![0.0; count.iter().product()]))
+                        .map(|(key, count)| (key.as_str(), vec![0.0; count.iter().product()]))
                         .collect(),
                 },
             )

--- a/crates/cervo-onnx/tests/infer-complex.rs
+++ b/crates/cervo-onnx/tests/infer-complex.rs
@@ -2,7 +2,7 @@
 // Copyright © 2022, Embark Studios AB, all rights reserved.
 // Created: 10 May 2022
 
-use cervo_core::prelude::{EpsilonInjector, Inferer};
+use cervo_core::prelude::{EpsilonInjector, Inferer, InfererExt};
 
 #[path = "./helpers.rs"]
 mod helpers;
@@ -17,8 +17,9 @@ fn test_infer_once_complex() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(1, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(1, &shapes);
+    let result = instance.infer_batch(observations);
 
     assert!(result.is_ok());
     let result = result.unwrap();
@@ -38,8 +39,9 @@ fn test_infer_once_complex_batched() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(10, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(10, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();
@@ -59,8 +61,9 @@ fn test_infer_once_complex_batched_not_loaded() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(10, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(10, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();
@@ -80,8 +83,9 @@ fn test_infer_once_complex_fixed_batch() {
     )
     .unwrap();
 
-    let observations = helpers::build_inputs_from_desc(7, instance.input_shapes());
-    let result = instance.infer(observations);
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(7, &shapes);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();

--- a/crates/cervo-onnx/tests/infer-simple.rs
+++ b/crates/cervo-onnx/tests/infer-simple.rs
@@ -6,7 +6,7 @@
 
 */
 
-use cervo_core::prelude::{EpsilonInjector, Inferer};
+use cervo_core::prelude::{EpsilonInjector, Inferer, InfererExt};
 
 #[path = "./helpers.rs"]
 mod helpers;
@@ -17,9 +17,10 @@ fn test_infer_once_simple() {
     let instance = cervo_onnx::builder(&mut reader).build_basic().unwrap();
     let mut instance = EpsilonInjector::wrap(instance, "epsilon").unwrap();
 
-    let observations = helpers::build_inputs_from_desc(1, instance.input_shapes());
+    let shapes = instance.input_shapes().to_vec();
+    let observations = helpers::build_inputs_from_desc(1, &shapes);
 
-    let result = instance.infer(observations);
+    let result = instance.infer_batch(observations);
     assert!(result.is_ok());
 
     let result = result.unwrap();

--- a/crates/cervo/src/main.rs
+++ b/crates/cervo/src/main.rs
@@ -10,14 +10,14 @@ use commands::Command;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
-struct Tractor {
+struct Cervo {
     #[clap(subcommand)]
     command: Command,
 }
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-    let args = Tractor::parse();
+    let args = Cervo::parse();
 
     commands::run(args.command)
 }


### PR DESCRIPTION
### Description of Changes

This adds a batcher API to help with async/multi-frame flows. The batcher can gather data from one or more sets of agents; and delay actual execution until a later point. This helps achieve larger batch sizes, which leads to better amortized performance as small batches degenerate into Matrix-Vector multiplications.

More details in the changelog file; which is a good starting point for review.

Graph for performance. Orange = new. Lower = better.

<img width="463" alt="image" src="https://user-images.githubusercontent.com/8234817/181069711-f0896884-322c-4c9c-975d-322b7194f58e.png">


Fixes #24, #8