### PR TITLE
Upgrade `perchance` to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- Upgrade to `perchance` v0.4.0, which removes dependency on `macaw` and `glam`
+
 ## [0.3.0] - 2022-10-04
 
 ### Batching
@@ -18,20 +21,20 @@ batching. To do this; there's a few changes that'll require updating
 your code. These should generally be fairly simple, and in some-cases
 as simple as removing `.to_owned()` and renaming a function call.
 
-* There's no owned strings in inputs and outputs. This saves
+- There's no owned strings in inputs and outputs. This saves
   (`model-input-arity + model-output-arity) * avg-batch-size`
   string allocations on each call.
-  * The values are still owned, as they act as sink/sourced. However;
-	internally there's been multiple allocations removed per batch
-	element.
-* The `InfererExt::infer` trait has been deprecated in favor of
+  - The values are still owned, as they act as sink/sourced. However;
+ internally there's been multiple allocations removed per batch
+ element.
+- The `InfererExt::infer` trait has been deprecated in favor of
   `InfererExt::infer_single` and `InfererExt::infer_batch` which
   allows some small optimizations while clarifying the API.
 
 Thus, to upgrade you'll need to:
 
-* Change how you build your batches to cache the input names.
-* Update which infer call function you use.
+- Change how you build your batches to cache the input names.
+- Update which infer call function you use.
 
 There's also a new `Batcher` which will help with batch building,
 while also improving performance. Using this helper will further
@@ -41,7 +44,7 @@ reduce the number of allocations per call. On average, this is about a
 
 Other changes:
 
-* To match the new `Inferer` API; `NoiseGenerators` have to generate
+- To match the new `Inferer` API; `NoiseGenerators` have to generate
   noise in-place instead of into a new vector.
 
 ### Cervo Runtime
@@ -54,19 +57,19 @@ running with a batched mode will not see huge gains, it should
 hopefully provide a good building block and make adaptation easier in
 an ECS.
 
-### Other changes:
+### Other changes
 
-* In general, all forward passes of an inferer should now be
+- In general, all forward passes of an inferer should now be
   immutable, simplifying synchronization.
 
 ## [0.2.0] - 2022-07-11
 
-* Upgrade all dependencies to tract 0.17.1
-  * Fixes a memory leak when repeatedly creating inferers
+- Upgrade all dependencies to tract 0.17.1
+  - Fixes a memory leak when repeatedly creating inferers
 
 ### NNEF
 
-* The initialization routine is now global and called `init`, instead of per-thread.
+- The initialization routine is now global and called `init`, instead of per-thread.
 
 ## [0.1.0] - 2022-06-02
 
@@ -76,5 +79,4 @@ Initial release.
 [Unreleased]: https://github.com/EmbarkStudios/cervo/compare/0.3.0...HEAD
 [0.3.0]: https://github.com/EmbarkStudios/cervo/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/EmbarkStudios/cervo/compare/0.1.1...0.2.0
-[0.1.1]: https://github.com/EmbarkStudios/cervo/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/EmbarkStudios/cervo/releases/tag/0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,12 +391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glam"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-
-[[package]]
 name = "half"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,16 +556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "macaw"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781d94ea559f76030086786c74fdf28d768535269653382f39824562fd02e73"
-dependencies = [
- "glam",
- "num-traits",
 ]
 
 [[package]]
@@ -762,11 +746,10 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "perchance"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6268b17d3b26bf66d772097e4826f4d99d9661f427bcc02b361f31b38b443b"
+checksum = "262ea49a93cf5c8d911d320b56967a64aec6fc403d35d915959e6d72e5bbace9"
 dependencies = [
- "macaw",
  "once_cell",
  "ordered-float",
 ]

--- a/benchmarks/perf-test/Cargo.toml
+++ b/benchmarks/perf-test/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = { version = "1.0"}
 cervo-onnx = { path = "../../crates/cervo-onnx" }
 cervo-nnef = { path = "../../crates/cervo-nnef" }
 cervo-core = { path = "../../crates/cervo-core" }
-perchance = "0.3"
+perchance = { version = "0.4", default-features = false }

--- a/crates/cervo-core/Cargo.toml
+++ b/crates/cervo-core/Cargo.toml
@@ -20,5 +20,5 @@ tract-core =  { version = "0.17.1" }
 tract-hir =  { version = "0.17.1" }
 rand = { version = "0.8.2" }
 rand_distr = { version = "0.4" }
-perchance = { version = "^0.3"}
+perchance = { version = "0.4", default-features = false }
 parking_lot = "0.12"


### PR DESCRIPTION
Removes dependency on `macaw` and `glam` which got quite messy as that makes `ark` use old versions of its own dependencies from the repo.

This is still the case now with `perchance` which is also not ideal, but at least the impact of just `perchance` is much smaller than also having all of `glam` and `macaw` duplicated.
