### PR TITLE
Replace `drain()` with `while` + `pop()` to preserve queue ordering

### DIFF
--- a/crates/cervo-runtime/src/runtime.rs
+++ b/crates/cervo-runtime/src/runtime.rs
@@ -285,16 +285,22 @@ mod tests {
         assert!(res.contains_key(&keys[0]));
         assert!(res.contains_key(&keys[1]));
 
-        // queue should be 2, 0, 1
         let res = runtime.run_for(Duration::from_secs_f32(0.07)).unwrap();
         assert_eq!(res.len(), 1);
         assert!(res.contains_key(&keys[2]));
 
-        push(&mut runtime, &keys);
+        // queue should be 3, 0, 1, 2
         let res = runtime.run_for(Duration::from_secs_f32(0.07)).unwrap();
-        assert_eq!(res.len(), 2, "got keys: {:?}", res.keys());
+        assert_eq!(res.len(), 1);
+        assert!(res.contains_key(&keys[3]));
+
+        push(&mut runtime, &keys);
+        let res = runtime.run_for(Duration::from_secs_f32(0.161)).unwrap();
+        assert_eq!(res.len(), 4, "got keys: {:?}", res.keys());
         assert!(res.contains_key(&keys[0]));
         assert!(res.contains_key(&keys[1]));
+        assert!(res.contains_key(&keys[2]));
+        assert!(res.contains_key(&keys[3]));
     }
 
     #[test]

--- a/crates/cervo-runtime/src/runtime.rs
+++ b/crates/cervo-runtime/src/runtime.rs
@@ -110,7 +110,8 @@ impl Runtime {
         let mut executed: Vec<BrainId> = vec![];
         let mut non_executed = vec![];
 
-        for ticket in self.queue.drain() {
+        while !self.queue.is_empty() {
+            let ticket = self.queue.pop().unwrap();
             let res = match self.models.iter().find(|m| m.id == ticket.1) {
                 Some(model) => {
                     if !model.needs_to_execute() || any_executed && !model.can_run_in_time(duration)
@@ -261,7 +262,7 @@ mod tests {
     fn test_run_for_rotation() {
         let mut runtime = Runtime::new();
         let mut keys = vec![];
-        for sleep in [0.02, 0.04, 0.06] {
+        for sleep in [0.02, 0.04, 0.06, 0.04] {
             keys.push(runtime.add_inferer(DummyInferer {
                 sleep_duration: Duration::from_secs_f32(sleep),
             }));


### PR DESCRIPTION
`BinaryHeap`s `drain()` method only drains the heap in arbitrary order. The rotation test didn't catch it, as the arbitrary order is deterministic and happened to be correct. This PR changes the test so that the old drain method fails and replaces drain with a while + pop combination. 
