### PR TITLE
cleanup pre-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 *.csv
 benchmarks/out
 /benchmarks/perf-test/target/
+/benchmarks/perf-test/*.png

--- a/crates/cervo-cli/Cargo.toml
+++ b/crates/cervo-cli/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 tempfile = "3.4"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
-cervo = { path = "../cervo" }
+cervo = { version = "0.4.1-alpha.0", path = "../cervo" }
 
 [[bin]]
 name = "cervo"


### PR DESCRIPTION
Planning to release 0.5.0-rc.0 so we can test it E2E in playtests. `cargo-release` has gotten nittier about some things so fixing these before going there.