### PR TITLE
Small fixes before releasing stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "instant"
@@ -476,7 +476,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.3",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",

--- a/deny.toml
+++ b/deny.toml
@@ -178,7 +178,7 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+    { name = "cervo-cli", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/release.toml
+++ b/release.toml
@@ -2,3 +2,4 @@ pre-release-commit-message = "Release {{version}}"
 tag-message = "Release {{version}}"
 tag-name = "{{version}}"
 consolidate-commits = true
+shared-version = true


### PR DESCRIPTION
One of our deps (`hermit-abi@0.3.1`) had been yanked, so bumped it. Also found some other `cargo deny` issues so the whole CLI component from duplicate version detection since it's not going to be a problem for "downstream integrations".