### PR TITLE
Do not ignore output shapes when building ONNX InferenceModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+- Do not ignore output shapes when constructing `onnx`-based inference models.
+
 ## [0.5.0] - 2023-10-09
 
 - Mark cervo_runtime::BrainId as #[must_use]

--- a/crates/cervo-cli/src/commands/benchmark.rs
+++ b/crates/cervo-cli/src/commands/benchmark.rs
@@ -173,8 +173,8 @@ pub(super) fn run(config: Args) -> Result<()> {
             let shapes = inferer
                 .input_shapes()
                 .iter()
-                .cloned()
                 .filter(|(k, _)| k.as_str() != epsilon)
+                .cloned()
                 .collect::<Vec<_>>();
 
             let observations = build_inputs_from_desc(batch_size as u64, &shapes);

--- a/crates/cervo-cli/src/commands/run.rs
+++ b/crates/cervo-cli/src/commands/run.rs
@@ -88,8 +88,8 @@ pub(super) fn run(config: Args) -> Result<()> {
         let shapes = inferer
             .input_shapes()
             .iter()
-            .cloned()
             .filter(|(k, _)| k.as_str() != epsilon)
+            .cloned()
             .collect::<Vec<_>>();
 
         let observations = build_inputs_from_desc(config.batch_size as u64, &shapes);

--- a/crates/cervo-onnx/src/lib.rs
+++ b/crates/cervo-onnx/src/lib.rs
@@ -36,7 +36,7 @@ use tract_onnx::{prelude::*, tract_hir::infer::Factoid};
 pub use tract_onnx;
 
 fn model_for_reader(reader: &mut dyn Read) -> Result<InferenceModel> {
-    let onnx = tract_onnx::onnx();
+    let onnx = tract_onnx::onnx().with_ignore_output_shapes(false);
     onnx.model_for_read(reader)
 }
 


### PR DESCRIPTION
### Description of Changes

We ran in to an issue where a onnx-based `InferenceModel` did not contain any output-shape information for onnx models with dynamic output shapes. This change fixes this issue by specifying to not ignore output shapes before building the `InferenceModel`.
