### PR TITLE
Upgrade to `perchance` v0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+- Upgrade to `perchance` v0.5
+
 ## [0.5.1] - 2024-01-18
 - Do not ignore output shapes when constructing `onnx`-based inference models.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,9 +797,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "perchance"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262ea49a93cf5c8d911d320b56967a64aec6fc403d35d915959e6d72e5bbace9"
+checksum = "7150912aa69e961f55a2648901f14e07c864c78908f78e12cf8ec7a18a211c0c"
 dependencies = [
  "once_cell",
  "ordered-float",

--- a/benchmarks/perf-test/Cargo.toml
+++ b/benchmarks/perf-test/Cargo.toml
@@ -13,6 +13,6 @@ cervo-onnx = { path = "../../crates/cervo-onnx" }
 cervo-nnef = { path = "../../crates/cervo-nnef" }
 cervo-core = { path = "../../crates/cervo-core" }
 cervo-runtime = { path = "../../crates/cervo-runtime", features = ["threaded"] }
-perchance = { version = "0.4", default-features = false }
+perchance = { version = "0.5", default-features = false }
 rayon = { version = "1.5"}
 

--- a/crates/cervo-core/Cargo.toml
+++ b/crates/cervo-core/Cargo.toml
@@ -20,5 +20,5 @@ tract-core =  { workspace = true }
 tract-hir =  { workspace = true }
 rand = { version = "0.8.2" }
 rand_distr = { version = "0.4" }
-perchance = { version = "0.4", default-features = false }
+perchance = { version = "0.5", default-features = false }
 parking_lot = "0.12"


### PR DESCRIPTION
This will remove having duplicated `perchance` versions in `wim-app`.