### PR TITLE
[WIP] handle recurrent networks inside inferer

### DIFF
--- a/crates/cervo-core/src/batcher.rs
+++ b/crates/cervo-core/src/batcher.rs
@@ -98,9 +98,9 @@ impl Batcher {
         while self.scratch.batch_size > 0 {
             let preferred_batch_size = inferer.select_batch_size(self.scratch.batch_size);
 
-            let view = self.scratch.chunk(total_offset, preferred_batch_size);
+            let mut view = self.scratch.chunk(total_offset, preferred_batch_size);
 
-            inferer.infer_raw(view)?;
+            inferer.infer_raw(&mut view)?;
             total_offset += preferred_batch_size;
         }
 

--- a/crates/cervo-core/src/batcher/scratch.rs
+++ b/crates/cervo-core/src/batcher/scratch.rs
@@ -185,6 +185,30 @@ pub struct ScratchPadView<'a> {
 
 impl<'a> ScratchPadView<'a> {
     /// View of the input at location `slot`.
+    pub fn input_slot_with_id(&self, slot: usize) -> (&[u64], &[f32]) {
+        (
+            &self.pad.ids[self.batch_range.clone()],
+            self.pad.input_slot(slot, self.batch_range.clone()),
+        )
+    }
+
+    /// Mutable view of the input at location `slot`.
+    pub fn input_slot_mut_with_id(&mut self, slot: usize) -> (&[u64], &mut [f32]) {
+        (
+            &self.pad.ids[self.batch_range.clone()],
+            self.pad.inputs[slot].view_mut(self.batch_range.clone()),
+        )
+    }
+
+    /// Mutable view of the input at location `slot`.
+    pub fn output_slot_mut_with_id(&mut self, slot: usize) -> (&[u64], &mut [f32]) {
+        (
+            &self.pad.ids[self.batch_range.clone()],
+            self.pad.outputs[slot].view_mut(self.batch_range.clone()),
+        )
+    }
+
+    /// View of the input at location `slot`.
     pub fn input_slot(&self, slot: usize) -> &[f32] {
         self.pad.input_slot(slot, self.batch_range.clone())
     }

--- a/crates/cervo-core/src/epsilon.rs
+++ b/crates/cervo-core/src/epsilon.rs
@@ -177,7 +177,7 @@ where
         self.inner.select_batch_size(max_count)
     }
 
-    fn infer_raw(&self, mut batch: ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+    fn infer_raw(&self, batch: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
         let total_count = self.count * batch.len();
         let output = batch.input_slot_mut(self.index);
         self.generator.generate(total_count, output);
@@ -191,5 +191,13 @@ where
 
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         self.inner.output_shapes()
+    }
+
+    fn begin_agent(&mut self, id: u64) {
+        self.inner.begin_agent(id);
+    }
+
+    fn end_agent(&mut self, id: u64) {
+        self.inner.end_agent(id);
     }
 }

--- a/crates/cervo-core/src/inferer.rs
+++ b/crates/cervo-core/src/inferer.rs
@@ -90,13 +90,16 @@ pub trait Inferer {
     fn select_batch_size(&self, max_count: usize) -> usize;
 
     /// Execute the model on the provided pre-batched data.
-    fn infer_raw(&self, batch: ScratchPadView<'_>) -> Result<(), anyhow::Error>;
+    fn infer_raw(&self, batch: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error>;
 
     /// Retrieve the name and shapes of the model inputs.
     fn input_shapes(&self) -> &[(String, Vec<usize>)];
 
     /// Retrieve the name and shapes of the model outputs.
     fn output_shapes(&self) -> &[(String, Vec<usize>)];
+
+    fn begin_agent(&mut self, id: u64);
+    fn end_agent(&mut self, id: u64);
 }
 
 /// Helper trait to provide helper functions for loadable models.
@@ -213,7 +216,7 @@ impl Inferer for Box<dyn Inferer + Send> {
         self.as_ref().select_batch_size(max_count)
     }
 
-    fn infer_raw(&self, batch: ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+    fn infer_raw(&self, batch: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
         self.as_ref().infer_raw(batch)
     }
 
@@ -223,6 +226,14 @@ impl Inferer for Box<dyn Inferer + Send> {
 
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         self.as_ref().output_shapes()
+    }
+
+    fn begin_agent(&mut self, id: u64) {
+        self.as_mut().begin_agent(id);
+    }
+
+    fn end_agent(&mut self, id: u64) {
+        self.as_mut().end_agent(id);
     }
 }
 
@@ -231,7 +242,7 @@ impl Inferer for Box<dyn Inferer> {
         self.as_ref().select_batch_size(max_count)
     }
 
-    fn infer_raw(&self, batch: ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+    fn infer_raw(&self, batch: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
         self.as_ref().infer_raw(batch)
     }
 
@@ -241,5 +252,13 @@ impl Inferer for Box<dyn Inferer> {
 
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         self.as_ref().output_shapes()
+    }
+
+    fn begin_agent(&mut self, id: u64) {
+        self.as_mut().begin_agent(id);
+    }
+
+    fn end_agent(&mut self, id: u64) {
+        self.as_mut().end_agent(id);
     }
 }

--- a/crates/cervo-core/src/inferer/basic.rs
+++ b/crates/cervo-core/src/inferer/basic.rs
@@ -46,7 +46,7 @@ impl BasicInferer {
         Ok(Self { model, model_api })
     }
 
-    fn build_inputs(&self, obs: &ScratchPadView<'_>) -> Result<TVec<TValue>> {
+    fn build_inputs(&self, obs: &mut ScratchPadView<'_>) -> Result<TVec<TValue>> {
         let mut inputs = TVec::default();
 
         for (idx, (name, shape)) in self.model_api.inputs.iter().enumerate() {
@@ -72,8 +72,8 @@ impl Inferer for BasicInferer {
         1
     }
 
-    fn infer_raw(&self, mut pad: ScratchPadView<'_>) -> Result<(), anyhow::Error> {
-        let inputs = self.build_inputs(&pad)?;
+    fn infer_raw(&self, pad: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+        let inputs = self.build_inputs(pad)?;
 
         // Run the optimized plan to get actions back!
         let result = self.model.run(inputs)?;
@@ -93,4 +93,7 @@ impl Inferer for BasicInferer {
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         &self.model_api.outputs
     }
+
+    fn begin_agent(&mut self, _id: u64) {}
+    fn end_agent(&mut self, _id: u64) {}
 }

--- a/crates/cervo-core/src/inferer/dynamic.rs
+++ b/crates/cervo-core/src/inferer/dynamic.rs
@@ -58,7 +58,7 @@ impl DynamicInferer {
         Ok(this)
     }
 
-    fn build_inputs(&self, batch: &ScratchPadView<'_>) -> Result<TVec<TValue>> {
+    fn build_inputs(&self, batch: &mut ScratchPadView<'_>) -> Result<TVec<TValue>> {
         let size = batch.len();
 
         let mut inputs = TVec::default();
@@ -88,8 +88,8 @@ impl Inferer for DynamicInferer {
         max_count
     }
 
-    fn infer_raw(&self, mut pad: ScratchPadView<'_>) -> Result<(), anyhow::Error> {
-        let inputs = self.build_inputs(&pad)?;
+    fn infer_raw(&self, pad: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+        let inputs = self.build_inputs(pad)?;
 
         // Run the optimized plan to get actions back!
         let result = self.model.run(inputs)?;
@@ -109,4 +109,7 @@ impl Inferer for DynamicInferer {
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         &self.model_api.outputs
     }
+
+    fn begin_agent(&mut self, _id: u64) {}
+    fn end_agent(&mut self, _id: u64) {}
 }

--- a/crates/cervo-core/src/inferer/memoizing.rs
+++ b/crates/cervo-core/src/inferer/memoizing.rs
@@ -95,7 +95,7 @@ impl MemoizingDynamicInferer {
         Ok(this)
     }
 
-    fn build_inputs(&self, batch: &ScratchPadView<'_>) -> Result<TVec<TValue>> {
+    fn build_inputs(&self, batch: &mut ScratchPadView<'_>) -> Result<TVec<TValue>> {
         let size = batch.len();
 
         let mut inputs = TVec::default();
@@ -153,9 +153,9 @@ impl Inferer for MemoizingDynamicInferer {
         max_count
     }
 
-    fn infer_raw(&self, mut pad: ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+    fn infer_raw(&self, pad: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
         let count = pad.len();
-        let inputs = self.build_inputs(&pad)?;
+        let inputs = self.build_inputs(pad)?;
 
         let result = self.get_concrete_model(count)?.run(inputs)?;
 
@@ -174,4 +174,7 @@ impl Inferer for MemoizingDynamicInferer {
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         &self.model_api.outputs
     }
+
+    fn begin_agent(&mut self, _id: u64) {}
+    fn end_agent(&mut self, _id: u64) {}
 }

--- a/crates/cervo-core/src/lib.rs
+++ b/crates/cervo-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod batcher;
 pub mod epsilon;
 pub mod inferer;
 mod model_api;
+pub mod recurrent;
 
 /// Most core utilities are re-exported here.
 pub mod prelude {
@@ -27,5 +28,7 @@ pub mod prelude {
         BasicInferer, DynamicInferer, FixedBatchInferer, Inferer, InfererBuilder, InfererExt,
         InfererProvider, MemoizingDynamicInferer, Response, State,
     };
+
     pub use super::model_api::ModelApi;
+    pub use super::recurrent::{RecurrentInfo, RecurrentTracker};
 }

--- a/crates/cervo-core/src/recurrent.rs
+++ b/crates/cervo-core/src/recurrent.rs
@@ -1,0 +1,178 @@
+use std::collections::HashMap;
+
+use crate::{batcher::ScratchPadView, inferer::Inferer};
+use anyhow::{Context, Result};
+use parking_lot::RwLock;
+use tract_core::tract_data::TVec;
+
+pub struct RecurrentInfo {
+    pub inkey: String,
+    pub outkey: String,
+}
+
+struct RecurrentPair {
+    inslot: usize,
+    outslot: usize,
+    numels: usize,
+    offset: usize,
+}
+
+/// The [`RecurrentTracker`] wraps an inferer to manage states that
+/// are input/output in a recurrent fashion, instead of roundtripping
+/// them to the high-level code.
+pub struct RecurrentTracker<T: Inferer> {
+    inner: T,
+    keys: TVec<RecurrentPair>,
+    per_agent_states: RwLock<HashMap<u64, Box<[f32]>>>,
+    agent_state_size: usize,
+    // https://github.com/EmbarkStudios/cervo/issues/31
+    inputs: Vec<(String, Vec<usize>)>,
+    outputs: Vec<(String, Vec<usize>)>,
+}
+
+impl<T> RecurrentTracker<T>
+where
+    T: Inferer,
+{
+    /// Wraps the provided `inferer` to automatically track any keys that are both inputs/outputs.
+    pub fn wrap(inferer: T) -> Result<RecurrentTracker<T>> {
+        let inputs = inferer.input_shapes();
+        let outputs = inferer.output_shapes();
+
+        let mut keys = vec![];
+
+        for (inkey, inshape) in inputs {
+            for (outkey, outshape) in outputs {
+                if inkey == outkey && inshape == outshape {
+                    keys.push(RecurrentInfo {
+                        inkey: inkey.clone(),
+                        outkey: outkey.clone(),
+                    })
+                }
+            }
+        }
+
+        Self::new(inferer, keys)
+    }
+}
+
+impl<T> RecurrentTracker<T>
+where
+    T: Inferer,
+{
+    /// Create a new recurrency tracker for the model.
+    ///
+    pub fn new(inferer: T, info: Vec<RecurrentInfo>) -> Result<Self> {
+        let inputs = inferer.input_shapes();
+        let outputs = inferer.output_shapes();
+
+        let mut offset = 0;
+        let keys = info
+            .iter()
+            .map(|info| {
+                let inslot = inputs
+                    .iter()
+                    .position(|input| info.inkey == input.0)
+                    .with_context(|| format!("no input named {}", info.inkey))?;
+                let outslot = outputs
+                    .iter()
+                    .position(|output| info.outkey == output.0)
+                    .with_context(|| format!("no output named {}", info.outkey))?;
+
+                let numels = inputs[inslot].1.iter().product();
+                offset += numels;
+                Ok(RecurrentPair {
+                    inslot,
+                    outslot,
+                    numels,
+                    offset: offset - numels,
+                })
+            })
+            .collect::<Result<TVec<RecurrentPair>>>()?;
+
+        let inputs = inputs
+            .iter()
+            .filter(|(k, _)| !info.iter().any(|info| &info.inkey == k))
+            .cloned()
+            .collect::<Vec<_>>();
+        let outputs = outputs
+            .iter()
+            .filter(|(k, _)| !info.iter().any(|info| &info.outkey == k))
+            .cloned()
+            .collect::<Vec<_>>();
+        Ok(Self {
+            inner: inferer,
+            keys,
+            agent_state_size: offset,
+            inputs,
+            outputs,
+            per_agent_states: Default::default(),
+        })
+    }
+}
+
+impl<T> Inferer for RecurrentTracker<T>
+where
+    T: Inferer,
+{
+    fn select_batch_size(&self, max_count: usize) -> usize {
+        self.inner.select_batch_size(max_count)
+    }
+
+    fn infer_raw(&self, batch: &mut ScratchPadView<'_>) -> Result<(), anyhow::Error> {
+        for pair in &self.keys {
+            let (ids, indata) = batch.input_slot_mut_with_id(pair.inslot);
+
+            let mut offset = 0;
+            let states = self.per_agent_states.read();
+            for id in ids {
+                // if None, leave as zeros and pray
+                if let Some(state) = states.get(id) {
+                    indata[offset..offset + pair.numels]
+                        .copy_from_slice(&state[pair.offset..pair.offset + pair.numels])
+                }
+                offset += pair.numels;
+            }
+        }
+
+        self.inner.infer_raw(batch)?;
+
+        for pair in &self.keys {
+            let (ids, outdata) = batch.output_slot_mut_with_id(pair.outslot);
+
+            let mut offset = 0;
+            let mut states = self.per_agent_states.write();
+            for id in ids {
+                // if None, leave as zeros and pray
+                if let Some(state) = states.get_mut(id) {
+                    state[pair.offset..pair.offset + pair.numels]
+                        .copy_from_slice(&outdata[offset..offset + pair.numels])
+                }
+
+                offset += pair.numels;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn input_shapes(&self) -> &[(String, Vec<usize>)] {
+        &self.inputs
+    }
+
+    fn output_shapes(&self) -> &[(String, Vec<usize>)] {
+        &self.outputs
+    }
+
+    fn begin_agent(&mut self, id: u64) {
+        self.per_agent_states
+            .write()
+            .insert(id, vec![0.0; self.agent_state_size].into_boxed_slice());
+        self.inner.begin_agent(id);
+    }
+
+    fn end_agent(&mut self, id: u64) {
+        self.per_agent_states.write().remove(&id);
+        self.inner.end_agent(id);
+    }
+}

--- a/crates/cervo-core/tests/batcher.rs
+++ b/crates/cervo-core/tests/batcher.rs
@@ -4,11 +4,14 @@
 
 use std::{cell::RefCell, collections::HashMap};
 
-use cervo_core::prelude::{Batcher, Inferer, InfererExt, State};
+use cervo_core::{
+    batcher::ScratchPadView,
+    prelude::{Batcher, Inferer, InfererExt, State},
+};
 
 struct TestInferer<
     B: Fn(usize) -> usize,
-    R: Fn(cervo_core::batcher::ScratchPadView<'_>) -> anyhow::Result<(), anyhow::Error>,
+    R: Fn(ScratchPadView<'_>) -> anyhow::Result<(), anyhow::Error>,
 > {
     batch_size: B,
     raw: R,
@@ -19,16 +22,13 @@ struct TestInferer<
 impl<B, R> Inferer for TestInferer<B, R>
 where
     B: Fn(usize) -> usize,
-    R: Fn(cervo_core::batcher::ScratchPadView<'_>) -> anyhow::Result<(), anyhow::Error>,
+    R: Fn(ScratchPadView<'_>) -> anyhow::Result<(), anyhow::Error>,
 {
     fn select_batch_size(&self, max_count: usize) -> usize {
         (self.batch_size)(max_count)
     }
 
-    fn infer_raw(
-        &self,
-        batch: cervo_core::batcher::ScratchPadView<'_>,
-    ) -> anyhow::Result<(), anyhow::Error> {
+    fn infer_raw(&self, batch: &mut ScratchPadView<'_>) -> anyhow::Result<(), anyhow::Error> {
         (self.raw)(batch)
     }
 
@@ -39,6 +39,9 @@ where
     fn output_shapes(&self) -> &[(String, Vec<usize>)] {
         &self.out_shapes
     }
+
+    fn begin_agent(&mut self, _id: u64) {}
+    fn end_agent(&mut self, _id: u64) {}
 }
 
 #[test]

--- a/crates/cervo-runtime/src/state.rs
+++ b/crates/cervo-runtime/src/state.rs
@@ -141,7 +141,10 @@ impl ModelState {
 mod tests {
     use std::time::Duration;
 
-    use cervo_core::prelude::{Batcher, Inferer, State};
+    use cervo_core::{
+        batcher::ScratchPadView,
+        prelude::{Batcher, Inferer, State},
+    };
 
     use super::ModelState;
     use crate::{timing::TimingBucket, BrainId};
@@ -153,10 +156,7 @@ mod tests {
             0
         }
 
-        fn infer_raw(
-            &self,
-            _batch: cervo_core::batcher::ScratchPadView<'_>,
-        ) -> anyhow::Result<(), anyhow::Error> {
+        fn infer_raw(&self, _batch: &mut ScratchPadView<'_>) -> anyhow::Result<(), anyhow::Error> {
             Ok(())
         }
 
@@ -167,6 +167,9 @@ mod tests {
         fn output_shapes(&self) -> &[(String, Vec<usize>)] {
             &[]
         }
+
+        fn begin_agent(&mut self, _id: u64) {}
+        fn end_agent(&mut self, _id: u64) {}
     }
 
     #[test]


### PR DESCRIPTION
Would be used something like

```
use cervo_core::prelude::{BasicInferer, InfererExt, RecurrentTracker, RecurrentInfo};

let mut model_data = load_bytes("model.onnx");
let inference_model = tract_onnx::onnx().model_for_read(&mut model_data)?;

let inferer = BasicInferer::from_model(inference_model)?
    .with_default_epsilon("noise");

let mut recurrent = RecurrentTracker::new(inferer, vec![ RecurrentInfo { inkey: "gru_state", outkey: "gru_result" } ]);
recurrent.begin_agent(35);
```

There's a bug with how this works with the batcher due to partially mitigating #31 in the new code. I think I'll have to do something like `effective_inputs` and `raw_inputs`, and same for outputs. So the batcher will use `raw_inputs` to build the scratch-pads, but consumers would use `effective_inputs`... will think tomorrow.